### PR TITLE
_put_args not getting set

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -74,7 +74,7 @@ class REST_Controller extends Controller
 				$this->request->body = file_get_contents('php://input');
 
 		    	// Try and set up our PUT variables anyway in case its not
-		    	parse_str(file_get_contents('php://input'), $this->_put_args);
+		    	parse_str($this->request->body, $this->_put_args);
     		break;
 
         	case 'delete':


### PR DESCRIPTION
was doing simple tests with Curl PUT requests and noticed the PUT params were not getting set ($this->put() was empty).

I haven't much experience with pulling PUT params strategies for PHP but this change fixed the issue for me.  
Hope this is helpful,  thanks for this code, it's been very helpful.
