### PR TITLE
Added JSONP support for client side AJAX requests

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -22,6 +22,7 @@ class REST_Controller extends Controller
 		'xml' 		=> 'application/xml',
 		'rawxml' 	=> 'application/xml',
 		'json' 		=> 'application/json',
+		'jsonp' 	=> 'application/json',
 		'serialize' => 'application/vnd.php.serialized',
 		'php' 		=> 'text/plain',
 		'html' 		=> 'text/html',
@@ -810,6 +811,12 @@ class REST_Controller extends Controller
     private function _format_json($data = array())
     {
     	return json_encode($data);
+    }
+	
+	// Encode as JSONP
+    private function _format_jsonp($data = array())
+    {
+    	return $this->get('callback').'('.json_encode($data).')';
     }
 
     // Encode as Serialized array


### PR DESCRIPTION
@philsturgeon

We used your REST Server to create an API for the London Ontario budget data for open data hack day (ODHD) this past weekend and it was great!

GitHub user SomethingOn implemented JSONP on our API and we thought others might benefit from it as well. Many APIs (Vimeo and Google come to mind) support this type of access. It basically wraps the JSON with a callback function as defined by the client. 
