### PR TITLE
Welcome controller extends wrong class

### DIFF
--- a/application/controllers/welcome.php
+++ b/application/controllers/welcome.php
@@ -1,6 +1,6 @@
 <?php
 
-class Welcome extends Controller {
+class Welcome extends CI_Controller {
 
 	function Welcome()
 	{


### PR DESCRIPTION
codeigniter-restserver was upgraded to CI 2.0, but the Welcome controller wasn't changed and still extends the Controller class - which causes a fatal error.

Fixed in this commit
