### PR TITLE
PUT Request via JQuery and REST_Controller

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -77,7 +77,8 @@ class REST_Controller extends CI_Controller {
 				// If no file type is provided, this is probably just arguments
 				else
 				{
-					parse_str($this->request->body, $this->_put_args);
+					$tmp = file_get_contents('php://input');
+                    parse_str($tmp, $this->_put_args);
 				}
 				
 				break;


### PR DESCRIPTION
Maybe this is just an issue I had with how I was sending my PUT request, but I never saw variables until I looked at the REST_Controller. 

Here is my Jquery Call

<pre>
<code>
var formVars = $("#MyForm").serialize();
$.ajax({
   url: '/api/mycontroller/myfunction',
   type: 'PUT',
   data: formVars,
   dataType: 'json',
   headers: {'X-API-KEY':'MYKEY', 'name':formVars},
   error: function(jqXHR, textStatus, errorThrow){
     // i have an error
    success: function(data){
       // do stuff...
  });
</code></pre>


Then in the REST_Controller

<pre><code>
public function myfunction_put()
{
      echo "My Put Var:" . $this->put('name');
}
</code></pre>


Nothing got spit out till i modded the REST_Controller its self, I will make a pull request and if its all my fault due to it being rubish, just kill it and let me know that my ajax was messed up

Thanks,
Chris
