### PR TITLE
Auth and Login Overrides

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -672,7 +672,7 @@ class REST_Controller extends CI_Controller {
 
 	// SECURITY FUNCTIONS ---------------------------------------------------------
 
-	private function _check_login($username = '', $password = NULL)
+	protected function _check_login($username = '', $password = NULL)
 	{
 		if (empty($username))
 		{


### PR DESCRIPTION
Hi,

I've made two commits you may be interested in.
1. I couldn't get $config['auth_override_class_method'] working when the default was 'none' and the override was 'basic' - I think the issue is that you end up at _force_login which only looks at rest_auth in the config file and returns a 401 if rest_auth isn't basic or digest. I created a new function to return the desired auth method to get around this.
2. You can't override _check_login in a controller when it's a private function (as I wanted to check username and password against values in a db table), although you can if it's protected.There may be much better ways of doing this.

[Also; is there an existing way of making all methods in a class (i.e. an entire controller) use a different auth method, without having to keep on adding methods to auth_override_class_method? If not, I may look at rewriting _auth_override_check to look for a wildcard or something: not sure whether that makes sense to you as well?]
