### PR TITLE
limit bug, no log with bad api key, and version  

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -27,7 +27,7 @@ class REST_Controller extends CI_Controller {
 		'rawxml' => 'application/xml',
 		'json' => 'application/json',
 		'jsonp' => 'application/javascript',
-		'serialize' => 'application/vnd.php.serialized',
+		'serialized' => 'application/vnd.php.serialized',
 		'php' => 'text/plain',
 		'html' => 'text/html',
 		'csv' => 'application/csv'


### PR DESCRIPTION
I'm currently using the rest server in a work project, and I was having trouble trying to figure out a few things:

1) What version I was using, it had been a long time since I got my rest server, and wanted to update, but wasn't sure what version I was on. I added a comment on the top with the latest version.
2) when log is on, an I'm using an incorrect API key, it will not log. So added the code to log for this case.
3) Limits where allowing an extra call, if I set the limit to 1000 it will allow 1001 calls before denying API access.

I hope you find this helpful.

Onema
