### PR TITLE
List of ip addresses that can use an API key

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -217,7 +217,8 @@ $config['rest_logs_table'] = 'logs';
 	  `method` varchar(6) NOT NULL,
 	  `params` text NOT NULL,
 	  `api_key` varchar(40) NOT NULL,
-	  `ip_address` varchar(15) NOT NULL,
+    `is_public_key` tinyint(1)  NOT NULL DEFAULT NULL ,
+    `ip_addresses` TEXT NULL DEFAULT NULL ,
 	  `time` int(11) NOT NULL,
 	  `authorized` tinyint(1) NOT NULL,
 	  PRIMARY KEY (`id`)

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -434,8 +434,42 @@ class REST_Controller extends CI_Controller {
 
 			$this->rest->key = $row->key;
 			
-			isset($row->level) AND $this->rest->level = $row->level;
-			isset($row->ignore_limits) AND $this->rest->ignore_limits = $row->ignore_limits;
+			if(isset($row->level)) 
+      {
+        $this->rest->level = $row->level;
+      }
+
+			if(isset($row->ignore_limits)) 
+      {
+        $this->rest->ignore_limits = $row->ignore_limits;
+      }
+      
+      if(isset($row->is_public_key)) 
+      {
+        
+        // Check for a list of valid ip addresses 
+        if(isset($row->ip_addresses)) 
+        {
+          $list_ip_addresses = explode("\n", $row->ip_addresses);
+          $found_address = FALSE;
+          
+          foreach($list_ip_addresses as $ip_address) 
+          {
+            if($this->input->ip_address() == $ip_address) 
+            {
+              $found_address = TRUE;
+              break;
+            }
+          }
+          
+          return $found_address;
+        }
+        else 
+        {
+          // There should be at least one IP address for this public key.
+          return FALSE;
+        }
+      }
 
 			return TRUE;
 		}


### PR DESCRIPTION
adds a field to add a list of ip addresses to the api keys, and a is_public_key field. If the key is public a list of ip_addresses can be associated with the key. This is an alternative to the ip-whitelist, but is tight to the api key. I removed the ip_address field form the sql to create the key table and replaced it with ip_addresses as it does not seem to be in use (please correct me if I'm wrong).
