### PR TITLE
fix a problem with apache_request_header function and php as CGI

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -412,10 +412,10 @@ class REST_Controller extends CI_Controller {
 			{
 				$method = strtolower($this->input->post('_method'));
 			}
-	        else if ($this->input->server('HTTP_X_HTTP_METHOD_OVERRIDE'))
-	        {
-	            $method = strtolower($this->input->server('HTTP_X_HTTP_METHOD_OVERRIDE'));
-	        }			
+	        	else if ($this->input->server('HTTP_X_HTTP_METHOD_OVERRIDE'))
+		        {
+		            $method = strtolower($this->input->server('HTTP_X_HTTP_METHOD_OVERRIDE'));
+		        }			
 		}
 
 		if (in_array($method, array('get', 'delete', 'post', 'put')))


### PR DESCRIPTION
since the apache_request_headers function will work only if php was installed as apache mod ( http://php.net/manual/en/function.apache-request-headers.php check the change log ), i had a problem on the live server 
so i have change it a bit to check if its exist or not ..
if its not found use the getenv() function instead ..
