### PR TITLE
Fixed up correctly .foo extensions to work when get arguments provided

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -293,8 +293,8 @@ class REST_Controller extends CI_Controller {
 	{
 		$pattern = '/\.(' . implode('|', array_keys($this->_supported_formats)) . ')$/';
 
-		// Check if a file extension is used
-		if (preg_match($pattern, $this->uri->uri_string(), $matches))
+		// Check if a file extension is used when no get arguments provided
+		if (!$this->_get_args AND preg_match($pattern, $this->uri->uri_string(), $matches))
 		{
 			return $matches[1];
 		}


### PR DESCRIPTION
There was an error in the function _detect_output_format()

With api/example/user/id/1.json URL's, enter in the first condition, but leaves without cleaning the arguments, which is done in the second condition. 

Now, only enter in the first condition if the URL does not have arguments.
