### PR TITLE
Alt Apache_request_headers() formated

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -404,34 +404,35 @@ class REST_Controller extends CI_Controller {
 	 */
 
 	protected function _detect_method()
-                  {
+    {
 		$method = strtolower($this->input->server('REQUEST_METHOD'));
-		if( function_exists('apache_request_headers'))
-                                     {
-                                        $request_headers = apache_request_headers();
-                                     }
-                                    else 
-                                     {
-                                        $arh = array();
-                                        $rx_http = '/\AHTTP_/';
-                                        foreach($_SERVER as $key => $val)
-                                        {
-                                            if(preg_match($rx_http, '', $key))
-                                            {
-                                                $rx_matches = array();
-                                                $rx_matches = explode('_', $arh_key);
-                                                if( count($rx_matches) > 0 and strlen($arh_key) > 2 ) {
-                                                  foreach($rx_matches as $ak_key => $ak_val)
-                                                  {
-                                                     $rx_matches[$ak_key] = ucfirst($ak_val);
-                                                     $arh_key = implode('-', $rx_matches);
-                                                   }
-                                                   $arh[$arh_key] = $val;
-                                            }
-                                        }
-                                        $request_headers = $arh;
-                                     }
-                                     }
+			if (function_exists('apache_request_headers'))
+            {
+            	$request_headers = apache_request_headers();
+            }
+			else 
+			{
+				$arh = array();
+                $rx_http = '/\AHTTP_/';
+                foreach ($_SERVER as $key => $val)
+                {
+					if (preg_match($rx_http, '', $key))
+                    {
+                    	$rx_matches = array();
+                        $rx_matches = explode('_', $arh_key);
+                        if ( count($rx_matches) > 0 and strlen($arh_key) > 2 ) 
+                        {
+                        	foreach ($rx_matches as $ak_key => $ak_val)
+                            	{
+                                	$rx_matches[$ak_key] = ucfirst($ak_val);
+                                    $arh_key = implode('-', $rx_matches);
+                                }
+                            $arh[$arh_key] = $val;
+                        }
+                    }
+                    $request_headers = $arh;
+                }
+        	}
 
 		if ($this->config->item('enable_emulate_request'))
 		{


### PR DESCRIPTION
added alternate function for apache_request_headers() for servers not
running php as a apache module. Cleaned up formating issues in this function
