### PR TITLE
Limit DB bug

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -540,6 +540,7 @@ class REST_Controller extends CI_Controller {
 		$result = $this->rest->db
 						->where('uri', $this->uri->uri_string())
 						->where('api_key', $this->rest->key)
+						->order_by("hour_started", "desc")
 						->get(config_item('rest_limits_table'))
 						->row();
 


### PR DESCRIPTION
Hey Phil,

As per my email, this is the pull request for the "limit" DB bug I was talking about.

I was having an issue with the library, in that when a URI and key was in the database, then another request came along, instead of adding to the count, it would create another row. So instead of the URI's count increasing by one, it would just create another record.

That meant limits weren't working. 

I could _well_ be wrong, but it seems to have fixed the problem for me.

Ta
