### PR TITLE
Fixed #75. Don't send content-length header when output compression is enabled.

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -295,7 +295,7 @@ class REST_Controller extends CI_Controller {
 		// but it will not modify the content-length header to compensate for
 		// the reduction, causing the browser to hang waiting for more data.
 		// We'll just skip content-length in those cases.
-		if ( ! $this->_zlib_oc)
+		if ( ! $this->_zlib_oc && ! $CFG->item('compress_output'))
 		{
 			header('Content-Length: ' . strlen($output));
 		}


### PR DESCRIPTION
https://github.com/philsturgeon/codeigniter-restserver/issues/75

If the output is compressed, the content-length header is wrong as it gives the length of the uncompressed output. Modified REST_Controller::response to only send the header when output compression is disabled.

see also: https://bugs.php.net/bug.php?id=44164
