### PR TITLE
Explicit object declaration 

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -38,6 +38,8 @@ class REST_Controller extends CI_Controller {
 	public function __construct()
 	{
 		parent::__construct();
+		$this->request = new stdClass();
+		$this->response = new stdClass();
 
 		$this->_zlib_oc = @ini_get('zlib.output_compression');
 


### PR DESCRIPTION
Was using this on the newly released PHP 5.4, and I was getting warnings because these two variables ($this->request and $this->response) were not explicitly declared as objects.  This code explicitly declares the objects to avoid the warning.
