### PR TITLE
Supporting HEAD and OPTIONS methods

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -281,9 +281,10 @@ class REST_Controller extends CI_Controller {
 
 		// Responce is simple for this case
 		if ($allow) {
-			$this->output->set_header('Allow: ' . join(', ', $allow));
+			header('Allow: ' . join(', ', $allow));
 		}
 		// no body, status code is 200 OK
+		exit;
 	}
 
 	/*


### PR DESCRIPTION
Is there any intention to implement HEAD and OPTIONS HTTP methods? HEAD is distinct from a truncated GET because it can be cheaper to check your database for the existence of an entry than retrieve and process it. OPTIONS can be automatic by use of "method_exists()" on the controller. These verbs are not excluded from REST practices even if they're rarely implemented.

I would also be interested in support for PATCH, it makes a lot of semantic sense to me. WebDAV methods like COPY or MOVE also sound useful but are not strictly RESTful nor are of interest to me.

I am soon to need these for a project so if there are no plans currently I will implement it myself. Would you then be interested in a pull request?
