### PR TITLE
Response where method doesn't exist is now "HTTP 405 Method Not Allowed"...

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -192,7 +192,7 @@ class REST_Controller extends CI_Controller {
 		// Sure it exists, but can they do anything with it?
 		if ( ! method_exists($this, $controller_method))
 		{
-			$this->response(array('status' => false, 'error' => 'Unknown method.'), 404);
+			$this->response(array('status' => false, 'error' => 'Unknown method.'), 405);
 		}
 
 		// Doing key related stuff? Can only do it if they have a key right?


### PR DESCRIPTION
... not "HTTP 404 Not Found". It may be the case that the resource exists, just that the specified method won't work.
