### PR TITLE
Fix for bug in Format.php's to_html()

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -146,8 +146,8 @@ class Format {
 	{
 		$data = $this->_data;
 		
-		// Multi-dimentional array
-		if (isset($data[0]))
+		// Multi-dimensional array
+		if (isset($data[0]) && is_array($data[0]))
 		{
 			$headings = array_keys($data[0]);
 		}


### PR DESCRIPTION
Fix for bug in Format.php's to_html() which failed to detect if $data was really a multidimensional array.

Prior, array('foo', 'bar', 'baz') would be considered a multidimensional array and spit out a PHP warning.
