### PR TITLE
Abstracted out the processes of firing a controller method

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -313,7 +313,20 @@ abstract class REST_Controller extends CI_Controller
 		}
 
 		// And...... GO!
-		call_user_func_array(array($this, $controller_method), $arguments);
+		$this->_fire_method(array($this, $controller_method), $arguments);
+	}
+
+	/**
+	 * Fire Method
+	 *
+	 * Fires the designated controller method with the given arguments.
+	 *
+	 * @param array $method The controller method to fire
+	 * @param array $args The arguments to pass to the controller method
+	 */
+	protected function _fire_method($method, $args)
+	{
+		call_user_func_array($method, $args);
 	}
 
 	/**


### PR DESCRIPTION
Hi Phil,

Not sure about your thoughts on this. I've found it useful when needing to insert a bit of logic before the controller method is fired (by overriding _fire_method()).

We could go an alternate way and actually create a hook-like method (e.g. pre_method_call()), like early_check().
