### PR TITLE
Use GET request for api key regardless of other datas request method.

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -171,6 +171,12 @@ abstract class REST_Controller extends CI_Controller
 
 		$this->{'_parse_' . $this->request->method}();
 
+		// The api key may be sent via get regardless of what method the other data used
+		if($this->request->method != 'get' && $this->config->item('rest_enable_keys'))
+		{
+			$this->{'_parse_get'}();
+		}
+
 		// Now we know all about our request, let's try and parse the body if it exists
 		if ($this->request->format and $this->request->body)
 		{


### PR DESCRIPTION
Allows api keys to be sent as a GET request regardless of what the other datas request method is. For example when using I/O Docs the api key is always sent as a GET request regardless of what the HTTPMethod is set to. This causes codeigniter-restserver to throw a Invalid API key error on methods that use a request other than GET.
