### PR TITLE
Removed a rogue closing round bracket

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -432,7 +432,7 @@ abstract class REST_Controller extends CI_Controller
 	 */
 	protected function _detect_ssl()
 	{
-    		return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on"));
+    		return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on");
 	}
 	
 	


### PR DESCRIPTION
I was just setting up a project and it was throwing an error on the extra closing break in the Rest Controller's _detect_ssl method. Not sure what was up with this but I fixed it. 
