### PR TITLE
Fixed issue #117 - Undefined property $this->db

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -232,7 +232,7 @@ abstract class REST_Controller extends CI_Controller
 		}
 
 		// Use whatever database is in use (isset returns false)
-		elseif (@$this->db)
+		elseif (property_exists($this, "db"))
 		{
 			$this->rest->db = $this->db;
 		}


### PR DESCRIPTION
This fix solves the problem mentioned in issue #117, i.e. messages like these:

ERROR - 2013-05-08 17:47:10 --> Severity: Notice  --> Undefined property: Example::$db REST_Controller.php 235

It uses the property_exists() function, which tests if a property is actually present.
