### PR TITLE
Escaping CSV headings

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -197,7 +197,7 @@ class Format {
 			$data = array($data);
 		}
 
-		$output = implode(',', $headings).PHP_EOL;
+		$output = '"'.implode('","', $headings).'"'.PHP_EOL;
 		foreach ($data as &$row)
 		{
 			$output .= '"'.implode('","', $row).'"'.PHP_EOL;


### PR DESCRIPTION
In **Format.php** only CSV data is escaped, escaping headings -as well- would resolve an issue of a heading including a comma

_Sample of Old O/P_

```
id,Heading with, Comma
"1","data with, comma"
```

_Sample of New O/P_

```
"id","Heading with, Comma"
"1","data with, comma"
```
