### PR TITLE
Simple addition to allow login via any library

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -68,10 +68,24 @@ $config['rest_auth'] = false;
 |
 | Is login required and if so, which user store do we use?
 |
-| '' = use config based users, 'ldap' = use LDAP authencation
+| '' = use config based users, 'ldap' = use LDAP authencation, 'library' = use a authentication library
 |
 */
 $config['auth_source'] = 'ldap';
+
+/*
+|--------------------------------------------------------------------------
+| REST Login
+|--------------------------------------------------------------------------
+|
+| If library authentication is used define the class and function name here
+|
+| The function should accept two parameters: class->function($username, $password)
+| In other cases override the function _perform_library_auth in your controller
+|
+*/
+$config['auth_library_class'] = '';
+$config['auth_library_function'] = '';
 
 /*
 |--------------------------------------------------------------------------

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1065,6 +1065,40 @@ abstract class REST_Controller extends CI_Controller
 	}
 
 	/**
+	 * Perform Library Authentication - Override this function to change the way the library is called
+	 *
+	 * @param string $username The username to validate
+	 * @param string $password The password to validate
+	 * @return boolean
+	 */
+	protected function _perform_library_auth($username = '', $password = NULL)
+	{
+		if (empty($username))
+		{
+			log_message('debug', 'Library Auth: failure, empty username');
+			return false;
+		}
+
+		$auth_library_class = strtolower($this->config->item('auth_library_class'));
+		$auth_library_function = strtolower($this->config->item('auth_library_function'));
+
+		if (empty($auth_library_class))
+		{
+			log_message('debug', 'Library Auth: failure, empty auth_library_class');
+			return false;
+		}
+
+		if (empty($auth_library_function))
+		{
+			log_message('debug', 'Library Auth: failure, empty auth_library_function');
+			return false;
+		}
+
+		$this->load->library($auth_library_class);
+		return $this->$auth_library_class->$auth_library_function($username, $password);
+	}
+
+	/**
 	 * Check if the user is logged in.
 	 *
 	 * @param string $username The user's name
@@ -1084,6 +1118,12 @@ abstract class REST_Controller extends CI_Controller
 		{
 			log_message('debug', 'performing LDAP authentication for $username');
 			return $this->_perform_ldap_auth($username, $password);
+		}
+
+		if ($auth_source == 'library')
+		{
+			log_message('debug', 'performing Library authentication for $username');
+			return $this->_perform_library_auth($username, $password);
 		}
 
 		$valid_logins = $this->config->item('rest_valid_logins');


### PR DESCRIPTION
Allow login via arbitrary library. 
_perform_library_auth can be overridden by the user to support libraries with another format.
