### PR TITLE
When outputting CSV escape double quotes per RFC 4180

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -200,6 +200,7 @@ class Format {
 		$output = implode(',', $headings).PHP_EOL;
 		foreach ($data as &$row)
 		{
+			$row = str_replace('"', '""', $row); // Escape dbl quotes per RFC 4180
 			$output .= '"'.implode('","', $row).'"'.PHP_EOL;
 		}
 


### PR DESCRIPTION
According to this RFC:

```
  7.  If double-quotes are used to enclose fields, then a double-quote
      appearing inside a field must be escaped by preceding it with
      another double quote.
```
