### PR TITLE
Added wildcard for setting class authen types

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -102,6 +102,11 @@ $config['auth_library_function'] = '';
 |			$config['auth_override_class_method']['deals']['insert'] = 'digest';
 |			$config['auth_override_class_method']['accounts']['user'] = 'basic';
 |
+| To set the authentication types for a class see example below:
+| 
+|
+| $config['auth_override_class_method']['class']['*'] = 'basic';
+|
 | Here 'deals' and 'accounts' are controller names, 'view', 'insert' and 'user' are methods within. (NOTE: leave off the '_get' or '_post' from the end of the method name)
 | Acceptable values are; 'none', 'digest' and 'basic'.
 |
@@ -109,7 +114,7 @@ $config['auth_library_function'] = '';
 // $config['auth_override_class_method']['deals']['view'] = 'none';
 // $config['auth_override_class_method']['deals']['insert'] = 'digest';
 // $config['auth_override_class_method']['accounts']['user'] = 'basic';
-
+// $config['auth_override_class_method']['class']['*'] = 'basic';//seet the entire classes authentication
 /*
 |--------------------------------------------------------------------------
 | REST Login usernames

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -876,7 +876,35 @@ abstract class REST_Controller extends CI_Controller
 		{
 			return false;
 		}
+		// check for wildcard flag for rules for classes
+		if(!empty($this->overrides_array[$this->router->class]['*'])){//check for class overides
+			// None auth override found, prepare nothing but send back a true override flag
+			if ($this->overrides_array[$this->router->class]['*'] == 'none')
+			{
+				return true;
+			}
 
+			// Basic auth override found, prepare basic
+			if ($this->overrides_array[$this->router->class]['*'] == 'basic')
+			{
+				$this->_prepare_basic_auth();
+				return true;
+			}
+
+			// Digest auth override found, prepare digest
+			if ($this->overrides_array[$this->router->class]['*'] == 'digest')
+			{
+				$this->_prepare_digest_auth();
+				return true;
+			}
+
+			// Whitelist auth override found, check client's ip against config whitelist
+			if ($this->overrides_array[$this->router->class]['*'] == 'whitelist')
+			{
+				$this->_check_whitelist_auth();
+				return true;
+			}
+		}
 		// Check to see if there's an override value set for the current class/method being called
 		if (empty($this->overrides_array[$this->router->class][$this->router->method]))
 		{


### PR DESCRIPTION
I added a wildcard method for classes so that authentication types can be defined for classes as well as methods. 

``` php
//Example of the config:
$config['auth_override_class_method']['class']['*'] = 'none';
```
