### PR TITLE
Add method check to access_check and extra data variable for controller use

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -325,8 +325,10 @@ $config['rest_access_table'] = 'access';
 |--------------------------------------------------------------------------
 |
 | When set to true REST_Controller will check the access table to see if 
-| the API KEY can access that controller.  rest_enable_keys *must* be enabled
-| to use this. 
+| the API KEY can access that controller and method. rest_enable_keys *must* 
+| be enabled to use this. Set the method column to * to allow access to all
+| methods in the controller. date_created and date_modified are optional.
+|
 |
 |	FALSE
 |
@@ -334,6 +336,7 @@ CREATE TABLE `access` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `key` varchar(40) NOT NULL DEFAULT '',
   `controller` varchar(50) NOT NULL DEFAULT '',
+  `method` varchar(50) NOT NULL DEFAULT '*',
   `date_created` datetime DEFAULT NULL,
   `date_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
So I setup my controller as api.php in controllers/ - works fine. I have about 6 methods defined in there for various things like adding and deleting dns records, adding and deleting links (for a resource page), etc. I went to use the access controller but I found that I can only limit access to my 'api' controller - not very useful. I want everyone to be able to update links, but only certain people to update dns. So I added a method column and check. If you set the method to \* (the default provided) then it works as before. Checking only the controller. Great, now I can lock down API calls per method. But I only want certain people to update certain dns records (or zones). So I add a preg_match in my controller for the data submitted. But what do I match it against? Data provided by an 'extra' column. This column and its use are completely optional, just like the user_id column in the proposed api keys table (thanks for that by the way!!!). If you add the column and put data in it, the data becomes available to the controller as $this->rest->extra_access. I hope others can find these change useful! 
