### PR TITLE
Controller Wildcard Authentication Rules

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -73,6 +73,8 @@ $config['rest_auth'] = false;
 |	If 'rest_auth' is 'session' then set 'auth_source' to the name of the session variable to check for.
 |
 */
+
+//change this to '' for wildcard unit test
 $config['auth_source'] = 'ldap';
 
 /*
@@ -103,15 +105,20 @@ $config['auth_library_function'] = '';
 |			$config['auth_override_class_method']['deals']['view'] = 'none';
 |			$config['auth_override_class_method']['deals']['insert'] = 'digest';
 |			$config['auth_override_class_method']['accounts']['user'] = 'basic';
+|			$config['auth_override_class_method']['dashboard']['*'] = 'none|digest|basic';
 |
-| Here 'deals' and 'accounts' are controller names, 'view', 'insert' and 'user' are methods within. (NOTE: leave off the '_get' or '_post' from the end of the method name)
+| Here 'deals', 'accounts' and 'dashboard' are controller names, 'view', 'insert' and 'user' are methods within. An asterisk may also be used to specify an authentication method for an entire classes methods. Ex: $config['auth_override_class_method']['dashboard']['*'] = 'basic'; (NOTE: leave off the '_get' or '_post' from the end of the method name)
 | Acceptable values are; 'none', 'digest' and 'basic'.
 |
 */
 // $config['auth_override_class_method']['deals']['view'] = 'none';
 // $config['auth_override_class_method']['deals']['insert'] = 'digest';
 // $config['auth_override_class_method']['accounts']['user'] = 'basic';
+// $config['auth_override_class_method']['dashboard']['*'] = 'basic';
 
+
+//---Uncomment list line for the wildard unit test
+//$config['auth_override_class_method']['wildcard_test_cases']['*'] = 'basic';
 /*
 |--------------------------------------------------------------------------
 | REST Login usernames

--- a/application/controllers/unit_tests/wildcard_test_cases.php
+++ b/application/controllers/unit_tests/wildcard_test_cases.php
@@ -1,0 +1,37 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Example
+ *
+ * This is a test for the wildcard .
+ *
+ * @package		CodeIgniter
+ * @subpackage	Rest Server
+ * @category	Controller
+ * @author		Allen Taylor
+ * @link		http://philsturgeon.co.uk/code/
+*/
+
+// This can be removed if you use __autoload() in config.php OR use Modular Extensions
+
+/*
+In order for this test to work you will need to change the auth_source option in the rest.php config file to '' and uncomment this line $config['auth_override_class_method']['wildcard_test_cases']['*'] = 'basic'; in the file as well. Once these are uncommented the tests will work.
+*/
+require APPPATH.'/libraries/REST_Controller.php'; 
+class Wildcard_test_cases extends REST_Controller{
+	function __construct(){
+		parent::__construct();
+		//set config for test
+		$this->config->load('rest');
+		$this->config->set_item('rest_auth', 'none');//turn on rest auth
+		$this->config->set_item('auth_source', '');//use config array for authentication
+		$this->config->set_item('auth_override_class_method', array('wildcard_test_cases' => array('*' => 'basic')));
+		$this->load->helper('url');
+	}
+
+
+	function digest_get(){
+		$this->response("welcome", 200);
+	}
+}
+?>

--- a/application/controllers/unit_tests/wildcard_test_harness.php
+++ b/application/controllers/unit_tests/wildcard_test_harness.php
@@ -1,0 +1,67 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Example
+ *
+ * This is a test for the wildcard. Wildcard allows you to specify an authentication type rule for an entire controller. Example would be $config['auth_override_class_method']['wildcard_test_cases']['*'] = 'basic'; This sets the authentication method for the Wildcard_test_harness controller to basic.
+ *
+ * @package		CodeIgniter
+ * @subpackage	Rest Server
+ * @category	Controller
+ * @author		Allen Taylor
+ * @link		http://philsturgeon.co.uk/code/
+*/
+
+// This can be removed if you use __autoload() in config.php OR use Modular Extensions
+
+/*
+In order for this test to work you will need to change the auth_source option in the rest.php config file to '' and uncomment this line $config['auth_override_class_method']['wildcard_test_cases']['*'] = 'basic'; in the file as well. Once these are uncommented the tests will work.
+*/
+class Wildcard_test_harness extends CI_Controller
+{
+	function __construct(){
+		parent::__construct();
+		$this->load->library('unit_test');
+		$this->load->helper('url');
+	}
+
+	//curl interface functions
+	private function makeRequest($url, $cred = '', $curlopts = array()){
+		$ch = curl_init($url);
+		$items = array(
+		    CURLOPT_URL => $url,
+		    CURLOPT_USERPWD => $cred
+		);
+		foreach($curlopts as $opt => $value)
+			$items[$opt] = $value;
+		curl_setopt_array($ch, $items);
+		ob_start();
+		$response = curl_exec($ch);
+		$contents = ob_get_contents();
+		ob_end_clean();
+		$info = curl_getinfo($ch);
+
+		$errno = curl_errno($ch);
+		$error = curl_error($ch);
+		curl_close($ch);
+		return array('response' => $response, 'contents' => $contents, 'errno' => $errno, 'error' => $error, 'info' => $info);//return 
+	}
+
+	/*
+	These two test cases will test if the authentication is working for the wildcard method. The curl requests may not work if you do not have an .htaccess file with mod rewrite in the same directory as your index.php file. If you don't have that file you can add it or change the url below to the one that includes index.php.
+	*/
+	function index(){
+
+		//not authorized
+		//no htaccess: $test = $this->makeRequest(base_url() . 'index.php/unit_tests/wildcard_test_cases/digest', '');
+		$test = $this->makeRequest(base_url() . 'unit_tests/wildcard_test_cases/digest', '');
+		// print_r($test);
+		$this->unit->run($test['info']['http_code'], '401', 'Not Authorized test (No credentials provided)');
+		//no htaccess: $test = $this->makeRequest(base_url() . 'index.php/unit_tests/wildcard_test_cases/digest', 'admin:1234');
+		$test = $this->makeRequest(base_url() . 'unit_tests/wildcard_test_cases/digest', 'admin:1234');
+		//print_r($test);
+		$this->unit->run($test['info']['http_code'], '200', 'Authorized, credentials given');
+		echo $this->unit->report();
+	}
+}
+?>

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -840,6 +840,36 @@ abstract class REST_Controller extends CI_Controller
             return false;
         }
 
+        // check for wildcard flag for rules for classes
+        if(!empty($this->overrides_array[$this->router->class]['*'])){//check for class overides
+            // None auth override found, prepare nothing but send back a true override flag
+            if ($this->overrides_array[$this->router->class]['*'] == 'none')
+            {
+                return true;
+            }
+
+            // Basic auth override found, prepare basic
+            if ($this->overrides_array[$this->router->class]['*'] == 'basic')
+            {
+                $this->_prepare_basic_auth();
+                return true;
+            }
+
+            // Digest auth override found, prepare digest
+            if ($this->overrides_array[$this->router->class]['*'] == 'digest')
+            {
+                $this->_prepare_digest_auth();
+                return true;
+            }
+
+            // Whitelist auth override found, check client's ip against config whitelist
+            if ($this->overrides_array[$this->router->class]['*'] == 'whitelist')
+            {
+                $this->_check_whitelist_auth();
+                return true;
+            }
+        }
+
         // Check to see if there's an override value set for the current class/method being called
         if (empty($this->overrides_array[$this->router->class][$this->router->method])) {
             return false;


### PR DESCRIPTION
I have re based and re submitted the pull request for the wildcard authentication for controllers. I also created a couple of unit tests for testing purposes. 

``` php
//example of config for controller dashboard
$config['auth_override_class_method']['dashboard']['*'] = 'none|digest|basic';
```
