### PR TITLE
Add Controller Sub-Folder Access Support

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1513,12 +1513,17 @@ abstract class REST_Controller extends CI_Controller
             return true;
         }
 
-        $controller = explode('/', $this->uri->uri_string());
+        // Fetch controller based on path and controller name
+        $controller = implode( '/', array($this->router->fetch_directory(), $this->router->fetch_class()) );
+        
+        // Remove any double slashes for safety
+        $controller = str_replace('//', '/', $controller);
 
+        // Build access table query
         $this->rest->db->select();
         $this->rest->db->where('key', $this->rest->key);
-        $this->rest->db->where('controller', $controller[0]);
-
+        $this->rest->db->where('controller', $controller);
+        
         $query = $this->rest->db->get(config_item('rest_access_table'));
 
         if ($query->num_rows > 0) {


### PR DESCRIPTION
Enables codeigniter-restserver to restrict access to controllers that
are in sub-folder paths. Useful for custom routers that allow arbitrary
controller sub folder organization PLUS compatibility with Codeigniter 3
controller sub-folders.

when specifying the controller to allow access to, if your controller is in a sub folder the database field would show 'path/to/controller/mycontroller'
