### PR TITLE
User defined configuration file

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -192,7 +192,7 @@ abstract class REST_Controller extends CI_Controller
      * Constructor function
      * @todo Document more please.
      */
-    public function __construct()
+    public function __construct($config = 'rest')
     {
         parent::__construct();
 
@@ -200,7 +200,7 @@ abstract class REST_Controller extends CI_Controller
         $this->_start_rtime = microtime(true);
 
         // Lets grab the config and get ready to party
-        $this->load->config('rest');
+        $this->load->config($config);
 
         // This library is bundled with REST_Controller 2.5+, but will eventually be part of CodeIgniter itself
         $this->load->library('format');


### PR DESCRIPTION
Make it possible to specify which configuration file to use when extending this class, in my example we have a pretty complex system where we have two different interfaces, where different groups of end users will use different authentication methods, one will use session based and another will use basic authentication, with this change you could enable that behaviour.
