### PR TITLE
Update _detect_ssl() to allow all valid values

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -520,7 +520,9 @@ abstract class REST_Controller extends CI_Controller
      */
     protected function _detect_ssl()
     {
-            return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on");
+    	    // $_SERVER['HTTPS'] (http://php.net/manual/en/reserved.variables.server.php)
+    	    // Set to a non-empty value if the script was queried through the HTTPS protocol
+            return (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']));
     }
 
 


### PR DESCRIPTION
Fixing to check if $_SERVER['HTTPS'] is non-empty instead of specifically 'on'.

According to PHP documentation this variable is "[s]et to a non-empty value if the script was queried through the HTTPS protocol." This caused incorrect 403 errors with a separate library that set the variable to "On" instead of "on". (http://php.net/manual/en/reserved.variables.server.php)