### PR TITLE
Fix for issue #408

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -960,7 +960,9 @@ abstract class REST_Controller extends CI_Controller
 
         // If no file type is provided, this is probably just arguments
         else {
-            parse_str(file_get_contents('php://input'), $this->_put_args);
+            if ($this->input->method() == 'put') {
+                $this->_put_args = $this->input->input_stream();
+            }
         }
 
     }
@@ -1001,7 +1003,9 @@ abstract class REST_Controller extends CI_Controller
 
         // If no file type is provided, this is probably just arguments
         else {
-            parse_str(file_get_contents('php://input'), $this->_patch_args);
+            if ($this->input->method() == 'patch') {
+                $this->_patch_args = $this->input->input_stream();
+            }
         }
     }
 
@@ -1011,7 +1015,9 @@ abstract class REST_Controller extends CI_Controller
     protected function _parse_delete()
     {
         // Set up out DELETE variables (which shouldn't really exist, but sssh!)
-        parse_str(file_get_contents('php://input'), $this->_delete_args);
+        if ($this->input->method() == 'delete') {
+            $this->_delete_args = $this->input->input_stream();
+        }
     }
 
     // INPUT FUNCTION --------------------------------------------------------------


### PR DESCRIPTION
Fix for issue #408

Updated _parse_put(), _parse_patch() and _parse_delete() functions to use CodeIgniter Input Class `$this->input->input_stream()` to fix conflicts between CI and the Restserver.

Also using `$this->input->method()` to check we have right type of request.