### PR TITLE
Correct "Only variables should be passed by reference" with end() functi...

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -570,7 +570,8 @@ abstract class REST_Controller extends CI_Controller
         elseif ($this->_get_args and !is_array(end($this->_get_args)) and preg_match($pattern, end($this->_get_args), $matches)) {
         //elseif ($this->_get_args and !is_array(end($this->_get_args)) and preg_match($pattern, end(array_keys($this->_get_args)), $matches)) {
             // The key of the last argument
-            $last_key = end(array_keys($this->_get_args));
+            $arg_keys = array_keys($this->_get_args);
+            $last_key = end($arg_keys);
 
             // Remove the extension from arguments too
             $this->_get_args[$last_key] = preg_replace($pattern, '', $this->_get_args[$last_key]);


### PR DESCRIPTION
...on

The end() function, by positioning the pointer to the end of the array, should get a variable instead of a value as a parameter.