### PR TITLE
Update REST_Controller.php

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1609,7 +1609,7 @@ abstract class REST_Controller extends CI_Controller
 
         $query = $this->rest->db->get(config_item('rest_access_table'));
 
-        if ($query->num_rows > 0) {
+        if ($query->num_rows() > 0) {
             return TRUE;
         }
 


### PR DESCRIPTION
The number of rows is returned by the method num_rows() in both the [2.2.0](http://www.codeigniter.com/user_guide/database/results.html)] and the [3.0](http://www.codeigniter.com/userguide3/database/results.html) documentation. The field num_rows was used in the past for caching but I guess it's not used anymore and returns null bcit-ci/CodeIgniter#1523. The _check_access() method will always return false even is there's a valid key/controller pair in the access table.