### PR TITLE
Fixed Missing rest_enabled_logging check for response code logging

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -500,7 +500,11 @@ abstract class REST_Controller extends CI_Controller
         }
 
         set_status_header($http_code);
-        $this->_log_response_code($http_code);
+        
+        // JC: Log response code only if rest logging enabled
+        if (config_item('rest_enable_logging')) {        
+            $this->_log_response_code($http_code);
+        }
         
         // If zlib.output_compression is enabled it will compress the output,
         // but it will not modify the content-length header to compensate for


### PR DESCRIPTION
As noted here https://github.com/chriskacerguis/codeigniter-restserver/issues/412#issuecomment-90352038