### PR TITLE
updated deprecated funtions in CI 3.0

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -950,7 +950,7 @@ abstract class REST_Controller extends CI_Controller
     protected function _parse_get()
     {
         // Fix for Issue #247
-        if ($this->input->is_cli_request()) {
+        if (is_cli()) {
             $args = $_SERVER['argv'];
             unset($args[0]);
             $_SERVER['QUERY_STRING'] =  $_SERVER['PATH_INFO'] = $_SERVER['REQUEST_URI'] = '/' . implode('/', $args) . '/';
@@ -1601,7 +1601,7 @@ abstract class REST_Controller extends CI_Controller
         }
 
         // Fetch controller based on path and controller name
-        $controller = implode( '/', array($this->router->fetch_directory(), $this->router->fetch_class()) );
+        $controller = implode( '/', array($this->router->directory, $this->router->class) );
 
         // Remove any double slashes for safety
         $controller = str_replace('//', '/', $controller);


### PR DESCRIPTION
According to Code Igniter documentation, those functions are deprecated in 3.0 and will be removed on 3.1
-  http://www.codeigniter.com/user_guide/installation/upgrade_300.html#uri-routing-methods-fetch-directory-fetch-class-fetch-method
- http://www.codeigniter.com/user_guide/installation/upgrade_300.html#input-library-method-is-cli-request
