### PR TITLE
Complete removal of JSON_NUMERIC_CHECK.

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -270,13 +270,13 @@ class Format {
 		{
 			// this is a jsonp request, the content-type must be updated to be text/javascript
 			header("Content-Type: application/javascript");
-			return $callback . "(" . json_encode($this->_data, JSON_NUMERIC_CHECK) . ");";
+			return $callback . '(' . json_encode($this->_data) . ');';
 		}
 		else
 		{
 			// we have an invalid jsonp callback identifier, we'll return plain json with a warning field
 			$this->_data['warning'] = "invalid jsonp callback provided: ".$callback;
-			return json_encode($this->_data, JSON_NUMERIC_CHECK);
+			return json_encode($this->_data);
 		}
 	}
 


### PR DESCRIPTION
JSON_NUMERIC_CHECK has been introduced with this commit: https://github.com/chriskacerguis/codeigniter-restserver/commit/e14659617b35a822a1df365b8203b038c0f8a100

This commit reverts JSON_NUMERIC_CHECK partly: https://github.com/chriskacerguis/codeigniter-restserver/commit/776a0fcfeb265ad9281114d8b5e28fe01b9d3917

I am proposing a full removal.