### PR TITLE
An addition that fixes #405, constants and various code tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ public function index_delete($id)
 }
 ```
 
-If query parameters are passed via the URL, regardless of whether it's a GET request, can be obtainable by the query method:
+If query parameters are passed via the URL, regardless of whether it's a GET request, can be obtained by the query method:
 
 ```php
 $this->query('blah'); // Query param

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ $ curl -X POST -H "X-API-KEY: some_key_here" http://example.com/books
 
 ## Contributions
 
-This project was originally written by Phil Sturgeon, however his involvment has shifted
+This project was originally written by Phil Sturgeon, however his involvement has shifted
 as he is no longer using it.  As of 11/20/2013 further developement and support will be done by Chris Kacerguis.
 
 Pull Requests are the best way to fix bugs or add features. I know loads of you use this, so please

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ public function index_delete($id)
 }
 ```
 
+If query parameters are passed via the URL, regardless of whether it's a GET request, can be obtainable by the query method:
+
+```php
+$this->query('blah'); // Query param
+```
+
 ## Content Types
 
 `REST_Controller` supports a bunch of different request/response formats, including XML, JSON and serialised PHP. By default, the class will check the URL and look for a format either as an extension or as a separate segment.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ $ curl -X POST -H "X-API-KEY: some_key_here" http://example.com/books
 ## Contributions
 
 This project was originally written by Phil Sturgeon, however his involvement has shifted
-as he is no longer using it.  As of 11/20/2013 further developement and support will be done by Chris Kacerguis.
+as he is no longer using it.  As of 2013/11/20 further developement and support will be done by Chris Kacerguis.
 
 Pull Requests are the best way to fix bugs or add features. I know loads of you use this, so please
 contribute if you have improvements to be made and I'll keep releasing versions over time.

--- a/application/controllers/api/Example.php
+++ b/application/controllers/api/Example.php
@@ -35,7 +35,7 @@ class Example extends REST_Controller {
     {
         if (!$this->get('id'))
         {
-            $this->response(NULL, 400);
+            $this->response(NULL, REST_Controller::BAD_REQUEST);
         }
 
         // $user = $this->some_model->getSomething( $this->get('id') );
@@ -49,12 +49,12 @@ class Example extends REST_Controller {
 
         if ($user)
         {
-            $this->response($user, 200); // 200 being the HTTP response code
+            $this->response($user, REST_Controller::OK); // OK (200) being the HTTP response code
         }
 
         else
         {
-            $this->response(['error' => 'User could not be found'], 404);
+            $this->response(['error' => 'User could not be found'], REST_Controller::NOT_FOUND);
         }
     }
 
@@ -68,7 +68,7 @@ class Example extends REST_Controller {
             'message' => 'Added a resource'
         ];
 
-        $this->response($message, 201); // 201 being the HTTP response code
+        $this->response($message, REST_Controller::CREATED); // CREATED (201) being the HTTP response code
     }
 
     function user_delete()
@@ -79,7 +79,7 @@ class Example extends REST_Controller {
             'message' => 'Deleted the resource'
         ];
 
-        $this->response($message, 204); // 204 being the HTTP response code
+        $this->response($message, REST_Controller::NO_CONTENT); // NO_CONTENT (204) being the HTTP response code
     }
 
     function users_get()
@@ -93,12 +93,12 @@ class Example extends REST_Controller {
 
         if ($users)
         {
-            $this->response($users, 200); // 200 being the HTTP response code
+            $this->response($users, REST_Controller::OK); // OK (200) being the HTTP response code
         }
 
         else
         {
-            $this->response(['error' => 'Couldn\'t find any users!'], 404);
+            $this->response(['error' => 'Couldn\'t find any users!'], REST_Controller::NOT_FOUND);
         }
     }
 

--- a/application/controllers/api/Key.php
+++ b/application/controllers/api/Key.php
@@ -47,14 +47,14 @@ class Key extends REST_Controller {
             $this->response([
                 'status' => 1,
                 'key' => $key
-            ], 201); // 201 = Created
+            ], REST_Controller::CREATED); // CREATED (201) being the HTTP response code
         }
         else
         {
             $this->response([
                 'status' => 0,
                 'error' => 'Could not save the key'
-            ], 500); // 500 = Internal Server Error
+            ], REST_Controller::INTERNAL_SERVER_ERROR); // INTERNAL_SERVER_ERROR (500) being the HTTP response code
         }
     }
 
@@ -77,7 +77,7 @@ class Key extends REST_Controller {
             // It doesn't appear the key exists
             $this->response([
                 'error' => 'Invalid API Key'
-            ], 400); // 400 = Bad Request
+            ], REST_Controller::BAD_REQUEST); // BAD_REQUEST (400) being the HTTP response code
         }
 
         // Destroy it
@@ -87,7 +87,7 @@ class Key extends REST_Controller {
         $this->response([
             'status' => 1,
             'success' => 'API Key was deleted'
-            ], 204); // 204 = Success, No Content
+            ], REST_Controller::NO_CONTENT); // NO_CONTENT (204) being the HTTP response code
     }
 
     // --------------------------------------------------------------------
@@ -110,7 +110,7 @@ class Key extends REST_Controller {
             // It doesn't appear the key exists
             $this->response([
                 'error' => 'Invalid API Key'
-            ], 400); // 400 = Bad Request
+            ], REST_Controller::BAD_REQUEST); // BAD_REQUEST (400) being the HTTP response code
         }
 
         // Update the key level
@@ -119,14 +119,14 @@ class Key extends REST_Controller {
             $this->response([
                 'status' => 1,
                 'success' => 'API Key was updated'
-            ], 200); // 200 = OK
+            ], REST_Controller::OK); // OK (200) being the HTTP response code
         }
         else
         {
             $this->response([
                 'status' => 0,
                 'error' => 'Could not update the key level'
-            ], 500); // 500 = Internal Server Error
+            ], REST_Controller::INTERNAL_SERVER_ERROR); // INTERNAL_SERVER_ERROR (500) being the HTTP response code
         }
     }
 
@@ -149,7 +149,7 @@ class Key extends REST_Controller {
             // It doesn't appear the key exists
             $this->response([
                 'error' => 'Invalid API Key'
-            ], 400); // 400 = Bad Request
+            ], REST_Controller::BAD_REQUEST); // BAD_REQUEST (400) being the HTTP response code
         }
 
         // Update the key level
@@ -158,14 +158,14 @@ class Key extends REST_Controller {
             $this->response([
                 'status' => 1,
                 'success' => 'Key was suspended'
-            ], 200); // 200 = OK
+            ], REST_Controller::OK); // OK (200) being the HTTP response code
         }
         else
         {
             $this->response([
                 'status' => 0,
                 'error' => 'Could not suspend the user'
-            ], 500); // 500 = Internal Server Error
+            ], REST_Controller::INTERNAL_SERVER_ERROR); // INTERNAL_SERVER_ERROR (500) being the HTTP response code
         }
     }
 
@@ -189,7 +189,7 @@ class Key extends REST_Controller {
             // It doesn't appear the key exists
             $this->response([
                 'error' => 'Invalid API Key'
-            ], 400); // 400 = Bad Request
+            ], REST_Controller::BAD_REQUEST); // BAD_REQUEST (400) being the HTTP response code
         }
 
         // Build a new key
@@ -204,14 +204,14 @@ class Key extends REST_Controller {
             $this->response([
                 'status' => 1,
                 'key' => $new_key
-            ], 201); // 201 = Created
+            ], REST_Controller::CREATED); // CREATED (201) being the HTTP response code
         }
         else
         {
             $this->response([
                 'status' => 0,
                 'error' => 'Could not save the key'
-            ], 500); // 500 = Internal Server Error
+            ], REST_Controller::INTERNAL_SERVER_ERROR); // INTERNAL_SERVER_ERROR (500) being the HTTP response code
         }
     }
 

--- a/application/controllers/api/Key.php
+++ b/application/controllers/api/Key.php
@@ -245,14 +245,19 @@ class Key extends REST_Controller {
 
     private function _get_key($key)
     {
-        return $this->db->where(config_item('rest_key_column'), $key)->get(config_item('rest_keys_table'))->row();
+        return $this->db
+			->where(config_item('rest_key_column'), $key)
+			->get(config_item('rest_keys_table'))
+			->row();
     }
 
     // --------------------------------------------------------------------
 
     private function _key_exists($key)
     {
-        return $this->db->where(config_item('rest_key_column'), $key)->count_all_results(config_item('rest_keys_table')) > 0;
+        return $this->db
+			->where(config_item('rest_key_column'), $key)
+			->count_all_results(config_item('rest_keys_table')) > 0;
     }
 
     // --------------------------------------------------------------------

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -49,7 +49,7 @@ class Format {
     /**
      * Default format of this class
      */
-    const DEFAULT_FORMAT = self::JSON; // Couldn't be DEFAULT, as this is a keyword
+    const DEFAULT_FORMAT = self::JSON_FORMAT; // Couldn't be DEFAULT, as this is a keyword
 
     /**
      * CodeIgniter instance

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -37,7 +37,6 @@ class Format {
      *
      * @param NULL $data
      * @param NULL $from_type
-     *
      * @throws Exception
      */
 
@@ -90,7 +89,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return array Data parsed as an array; otherwise, an empty array
      */
     public function to_array($data = NULL)
@@ -131,7 +129,6 @@ class Format {
      * to the constructor
      * @param NULL $structure
      * @param string $basenode
-     *
      * @return mixed
      */
     public function to_xml($data = NULL, $structure = NULL, $basenode = 'xml')
@@ -215,7 +212,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return mixed
      */
     public function to_html($data = NULL)
@@ -265,7 +261,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return mixed
      */
     public function to_csv($data = NULL)
@@ -311,7 +306,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return string Json representation of a value
      */
     public function to_json($data = NULL)
@@ -350,7 +344,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return string Serialized data
      */
     public function to_serialized($data = NULL)
@@ -370,7 +363,6 @@ class Format {
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed
      * to the constructor
-     *
      * @return mixed String representation of a variable
      */
     public function to_php($data = NULL)
@@ -389,7 +381,6 @@ class Format {
 
     /**
      * @param $data XML string
-     *
      * @return SimpleXMLElement XML element object; otherwise, empty array
      */
     protected function _from_xml($data)
@@ -399,7 +390,6 @@ class Format {
 
     /**
      * @param string $data CSV string
-     *
      * @return array A multi-dimensional array with the outer array being the number of rows
      * and the inner arrays the individual fields
      */
@@ -426,7 +416,6 @@ class Format {
 
     /**
      * @param $data Encoded json string
-     *
      * @return mixed Decoded json string with leading and trailing whitespace removed
      */
     protected function _from_json($data)
@@ -436,7 +425,6 @@ class Format {
 
     /**
      * @param string Data to unserialized
-     *
      * @return mixed Unserialized data
      */
     protected function _from_serialize($data)
@@ -446,7 +434,6 @@ class Format {
 
     /**
      * @param $data Data to trim leading and trailing whitespace
-     *
      * @return string Data with leading and trailing whitespace removed
      */
     protected function _from_php($data)

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -375,51 +375,6 @@ class Format {
     }
 
     /**
-     * Format data as CSV
-     *
-     * @param mixed|NULL $data Optional data to pass, so as to override the data passed
-     * to the constructor
-     * @return mixed
-     */
-    public function to_csv($data = NULL)
-    {
-        // If no data is passed as a parameter, then use the data passed
-        // via the constructor
-        if ($data === NULL && func_num_args() === 0)
-        {
-            $data = $this->_data;
-        }
-
-        // Cast as an array if not already
-        if (is_array($data) === FALSE)
-        {
-            $data = (array) $data;
-        }
-
-        // Multi-dimensional array
-        if (isset($data[0]) && is_array($data[0]))
-        {
-            $headings = array_keys($data[0]);
-        }
-
-        // Single array
-        else
-        {
-            $headings = array_keys($data);
-            $data = [$data];
-        }
-
-        $output = '"' . implode('","', $headings) . '"' . PHP_EOL;
-        foreach ($data as &$row)
-        {
-            $row = str_replace('"', '""', $row); // Escape dbl quotes per RFC 4180
-            $output .= '"' . implode('","', $row) . '"' . PHP_EOL;
-        }
-
-        return $output;
-    }
-
-    /**
      * Encode data as json
      *
      * @param mixed|NULL $data Optional data to pass, so as to override the data passed

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -408,7 +408,7 @@ class Format {
         $array = [];
 
         // Splits
-        $rows = explode("\n", trim($data));
+        $rows = explode(PHP_EOL, trim($data));
         $headings = explode(',', array_shift($rows));
         foreach ($rows as $row)
         {

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -12,6 +12,46 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class Format {
 
     /**
+     * Array output format
+     */
+    const ARRAY_FORMAT = 'array';
+
+    /**
+     * Comma Separated Value (CSV) output format
+     */
+    const CSV_FORMAT = 'csv';
+
+    /**
+     * Json output format
+     */
+    const JSON_FORMAT = 'json';
+
+    /**
+     * HTML output format
+     */
+    const HTML_FORMAT = 'html';
+
+    /**
+     * PHP output format
+     */
+    const PHP_FORMAT = 'php';
+
+    /**
+     * Serialized output format
+     */
+    const SERIALIZED_FORMAT = 'serialized';
+
+    /**
+     * XML output format
+     */
+    const XML_FORMAT = 'xml';
+
+    /**
+     * Default format of this class
+     */
+    const DEFAULT_FORMAT = self::JSON; // Couldn't be DEFAULT, as this is a keyword
+
+    /**
      * CodeIgniter instance
      *
      * @var object

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -560,7 +560,7 @@ abstract class REST_Controller extends CI_Controller {
             if ($this->config->item('rest_enable_limits') && $this->_check_limit($controller_method) === FALSE)
             {
                 $response = [$this->config->item('rest_status_field_name') => FALSE, $this->config->item('rest_message_field_name') => 'This API key has reached the time limit for this method.'];
-                $this->response($response, self:UNAUTHORIZED);
+                $this->response($response, self::UNAUTHORIZED);
             }
 
             // If no level is set use 0, they probably aren't using permissions
@@ -577,7 +577,7 @@ abstract class REST_Controller extends CI_Controller {
 
             // They don't have good enough perms
             $response = [$this->config->item('rest_status_field_name') => FALSE, $this->config->item('rest_message_field_name') => 'This API key does not have enough permissions.'];
-            $authorized || $this->response($response, self:UNAUTHORIZED);
+            $authorized || $this->response($response, self::UNAUTHORIZED);
         }
 
         // No key stuff, but record that stuff is happening
@@ -600,7 +600,7 @@ abstract class REST_Controller extends CI_Controller {
                         'classname' => get_class($ex),
                         'message' => $ex->getMessage()
                     ]
-                ], self:INTERNAL_SERVER_ERROR);
+                ], self::INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -206,6 +206,7 @@ abstract class REST_Controller extends CI_Controller {
      * Extend this function to apply additional checking early on in the process
      *
      * @access protected
+     * @return void
      */
     protected function early_checks()
     {
@@ -215,9 +216,9 @@ abstract class REST_Controller extends CI_Controller {
      * Constructor for the REST API
      *
      * @access public
-     *
      * @param string $config Configuration filename minus the file extension
      * e.g: my_rest.php is passed as 'my_rest'
+     * @return void
      */
     public function __construct($config = 'rest')
     {
@@ -381,6 +382,7 @@ abstract class REST_Controller extends CI_Controller {
      *
      * @author Chris Kacerguis
      * @access public
+     * @return void
      */
     public function __destruct()
     {
@@ -400,7 +402,6 @@ abstract class REST_Controller extends CI_Controller {
      * Controller method.
      *
      * @access public
-     *
      * @param  string $object_called
      * @param  array $arguments The arguments passed to the controller method.
      */
@@ -507,7 +508,6 @@ abstract class REST_Controller extends CI_Controller {
      * Takes mixed data and optionally a status code, then creates the response
      *
      * @access public
-     *
      * @param array|NULL $data Data to output to the user
      * @param int|NULL $http_code HTTP status code
      * @param bool $continue TRUE to flush the response to the client and continue
@@ -728,6 +728,7 @@ abstract class REST_Controller extends CI_Controller {
     /**
      * Get the HTTP request string e.g. get or post
      *
+     * @access protected
      * @return string|NULL Supported request method as a lowercase string; otherwise, NULL if not supported
      */
     protected function _detect_method()
@@ -867,9 +868,7 @@ abstract class REST_Controller extends CI_Controller {
      * Add the request to the log table
      *
      * @access protected
-     *
      * @param bool $authorized TRUE the user is authorized; otherwise, FALSE
-     *
      * @return bool TRUE the data was inserted; otherwise, FALSE
      */
     protected function _log_request($authorized = FALSE)
@@ -897,9 +896,7 @@ abstract class REST_Controller extends CI_Controller {
      * Check if the requests to a controller method exceed a limit
      *
      * @access protected
-     *
      * @param  string $controller_method The method being called
-     *
      * @return bool TRUE the call limit is below the threshold; otherwise, FALSE
      */
     protected function _check_limit($controller_method)
@@ -974,9 +971,7 @@ abstract class REST_Controller extends CI_Controller {
     }
 
     /**
-     * Auth override check
-     * Check if there is a specific auth type set for the current class/method
-     * being called.
+     * Check if there is a specific auth type set for the current class/method being called
      *
      * @access protected
      * @return bool
@@ -1189,7 +1184,6 @@ abstract class REST_Controller extends CI_Controller {
      * Parse the query parameters
      *
      * @access protected
-     *
      * @return void
      */
     public function _parse_query()
@@ -1226,11 +1220,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a GET request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the GET request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the GET request; otherwise, FALSE
      */
     public function get($key = NULL, $xss_clean = NULL)
@@ -1247,11 +1239,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a OPTIONS request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the OPTIONS request.
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the OPTIONS request; otherwise, FALSE
      */
     public function options($key = NULL, $xss_clean = NULL)
@@ -1268,11 +1258,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a HEAD request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the HEAD request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the HEAD request; otherwise, FALSE
      */
     public function head($key = NULL, $xss_clean = NULL)
@@ -1289,11 +1277,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a POST request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the POST request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the POST request; otherwise, FALSE
      */
     public function post($key = NULL, $xss_clean = NULL)
@@ -1310,11 +1296,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a PUT request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the PUT request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the PUT request; otherwise, FALSE
      */
     public function put($key = NULL, $xss_clean = NULL)
@@ -1331,11 +1315,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a DELETE request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the DELETE request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the DELETE request; otherwise, FALSE
      */
     public function delete($key = NULL, $xss_clean = NULL)
@@ -1352,11 +1334,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from a PATCH request
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the PATCH request
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the PATCH request; otherwise, FALSE
      */
     public function patch($key = NULL, $xss_clean = NULL)
@@ -1373,11 +1353,9 @@ abstract class REST_Controller extends CI_Controller {
      * Retrieve a value from the query parameters
      *
      * @access public
-     *
      * @param NULL $key Key to retrieve from the query parameters
      * If NULL an array of arguments is returned
      * @param NULL $xss_clean Whether to apply XSS filtering
-     *
      * @return array|string|FALSE Value from the query parameters; otherwise, FALSE
      */
     public function query($key = NULL, $xss_clean = NULL)
@@ -1395,10 +1373,8 @@ abstract class REST_Controller extends CI_Controller {
      * prevented.
      *
      * @access protected
-     *
      * @param  string $value Input data
      * @param  bool $xss_clean Whether to apply XSS filtering
-     *
      * @return string
      */
     protected function _xss_clean($value, $xss_clean)
@@ -1427,10 +1403,8 @@ abstract class REST_Controller extends CI_Controller {
      * Perform LDAP Authentication
      *
      * @access protected
-     *
      * @param  string $username The username to validate
      * @param  string $password The password to validate
-     *
      * @return bool
      */
     protected function _perform_ldap_auth($username = '', $password = NULL)
@@ -1536,10 +1510,8 @@ abstract class REST_Controller extends CI_Controller {
      * Perform Library Authentication - Override this function to change the way the library is called
      *
      * @access protected
-     *
      * @param  string $username The username to validate
      * @param  string $password The password to validate
-     *
      * @return bool
      */
     protected function _perform_library_auth($username = '', $password = NULL)
@@ -1580,10 +1552,8 @@ abstract class REST_Controller extends CI_Controller {
      * Check if the user is logged in
      *
      * @access protected
-     *
      * @param  string $username The user's name
      * @param  bool|string $password The user's password
-     *
      * @return bool
      */
     protected function _check_login($username = NULL, $password = FALSE)
@@ -1639,6 +1609,7 @@ abstract class REST_Controller extends CI_Controller {
      * Check to see if the user is logged in with a PHP session key
      *
      * @access protected
+     * @return void
      */
     protected function _check_php_session()
     {
@@ -1661,6 +1632,7 @@ abstract class REST_Controller extends CI_Controller {
      * Prepares for basic authentication
      *
      * @access protected
+     * @return void
      */
     protected function _prepare_basic_auth()
     {
@@ -1701,6 +1673,7 @@ abstract class REST_Controller extends CI_Controller {
      * Prepares for digest authentication
      *
      * @access protected
+     * @return void
      */
     protected function _prepare_digest_auth()
     {
@@ -1762,6 +1735,7 @@ abstract class REST_Controller extends CI_Controller {
      * Checks if the client's ip is in the 'rest_ip_blacklist' config and generates a 401 response
      *
      * @access protected
+     * @return void
      */
     protected function _check_blacklist_auth()
     {
@@ -1785,6 +1759,7 @@ abstract class REST_Controller extends CI_Controller {
      * Check if the client's ip is in the 'rest_ip_whitelist' config and generates a 401 response
      *
      * @access protected
+     * @return void
      */
     protected function _check_whitelist_auth()
     {
@@ -1807,9 +1782,9 @@ abstract class REST_Controller extends CI_Controller {
      * Force logging in by setting the WWW-Authenticate header
      *
      * @access protected
-     *
      * @param string $nonce A server-specified data string which should be uniquely generated
      * each time
+     * @return void
      */
     protected function _force_login($nonce = '')
     {
@@ -1842,7 +1817,6 @@ abstract class REST_Controller extends CI_Controller {
      *
      * @access protected
      * @author Chris Kacerguis
-     *
      * @return bool TRUE log table updated; otherwise, FALSE
      */
     protected function _log_access_time()
@@ -1861,9 +1835,7 @@ abstract class REST_Controller extends CI_Controller {
      *
      * @access protected
      * @author Justin Chen
-     *
      * @param $http_code int HTTP status code
-     *
      * @return bool TRUE log table updated; otherwise, FALSE
      */
     protected function _log_response_code($http_code)

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -712,10 +712,10 @@ abstract class REST_Controller extends CI_Controller {
     /**
      * Get the input format e.g. json or xml
      *
-     * @access private
+     * @access protected
      * @return string|NULL Supported input format; otherwise, NULL
      */
-    private function _detect_input_format()
+    protected function _detect_input_format()
     {
         // Get the CONTENT-TYPE value from the SERVER variable
         $contentType = $this->input->server('CONTENT_TYPE');

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -121,7 +121,7 @@ abstract class REST_Controller extends CI_Controller {
     protected $_options_args = [];
 
     /**
-     * The arguments from GET, POST, PUT, DELETE request methods combined.
+     * The arguments from GET, POST, PUT, DELETE, PATCH, HEAD and OPTIONS request methods combined
      *
      * @var array
      */

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1379,7 +1379,7 @@ abstract class REST_Controller extends CI_Controller {
     {
         $string = strip_tags($this->form_validation->error_string());
 
-        return explode("\n", trim($string, "\n"));
+        return explode(PHP_EOL, trim($string, PHP_EOL));
     }
 
     // SECURITY FUNCTIONS ---------------------------------------------------------

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -202,6 +202,102 @@ abstract class REST_Controller extends CI_Controller {
      */
     protected $_enable_xss = FALSE;
 
+    // Success
+
+    /**
+     * The request has succeeded
+     */
+    const OK = 200;
+
+    /**
+     * The server successfully created a new resource
+     */
+    const CREATED = 201;
+
+    /**
+     * The server successfully processed the request, though no content is returned
+     */
+    const NO_CONTENT = 204;
+
+    // Redirection
+
+    /**
+     * The resource has not been modified since the last request
+     */
+    const NOT_MODIFIED = 304;
+
+    // Client Error
+
+    /**
+     * The request cannot be fulfilled due to multiple errors
+     */
+    const BAD_REQUEST = 400;
+
+    /**
+     * The user is unauthorized to access the requested resource
+     */
+    const UNAUTHORIZED = 401;
+
+    /**
+     * The requested resource is unavailable at this present time
+     */
+    const FORBIDDEN = 403;
+
+    /**
+     * The requested resource could not be found
+     *
+     * Note: This is sometimes used to mask if there was an UNAUTHORIZED (401) or
+     * FORBIDDEN (403) error, for security reasons
+     */
+    const NOT_FOUND = 404;
+
+    /**
+     * The request method is not supported by the following resource
+     */
+    const METHOD_NOT_ALLOWED = 405;
+
+    /**
+     * The request could not be completed due to a conflict with the current state
+     * of the resource
+     */
+    const CONFLICT = 409;
+
+    // Server Error
+
+    /**
+     * The server encountered an unexpected error
+     *
+     * Note: This is a generic error message when no specific message
+     * is suitable
+     */
+    const INTERNAL_SERVER_ERROR = 500;
+
+    /**
+     * The server does not recognised the request method
+     */
+    const NOT_IMPLEMENTED = 501;
+
+    /**
+     * HTTP status codes and their respective description
+     *
+     * @var array
+     * @link http://www.restapitutorial.com/httpstatuscodes.html
+     */
+    protected $http_status_codes = [
+        self::OK => 'OK',
+        self::CREATED => 'CREATED',
+        self::NO_CONTENT => 'NO CONTENT',
+        self::NOT_MODIFIED => 'NOT MODIFIED',
+        self::BAD_REQUEST => 'BAD REQUEST',
+        self::UNAUTHORIZED => 'UNAUTHORIZED',
+        self::FORBIDDEN => 'FORBIDDEN',
+        self::NOT_FOUND => 'NOT FOUND',
+        self::METHOD_NOT_ALLOWED => 'METHOD NOT ALLOWED',
+        self::CONFLICT => 'CONFLICT',
+        self::INTERNAL_SERVER_ERROR => 'INTERNAL SERVER ERROR',
+        self::NOT_IMPLEMENTED => 'NOT IMPLEMENTED'
+    ];
+
     /**
      * Extend this function to apply additional checking early on in the process
      *

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -905,8 +905,8 @@ abstract class REST_Controller extends CI_Controller {
         $limit = $this->methods[$controller_method]['limit'];
 
         $uri_noext = $this->uri->uri_string();
-        if (strpos(strrev($this->uri->uri_string()), strrev($this->response->format)) === 0) 
-        { 
+        if (strpos(strrev($this->uri->uri_string()), strrev($this->response->format)) === 0)
+        {
             $uri_noext = substr($this->uri->uri_string(),0, -strlen($this->response->format)-1);
         }
 

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -803,13 +803,13 @@ abstract class REST_Controller extends CI_Controller {
                     else
                     {
                         // If it is truly HTML, it wont want any XML
-                        if ($format == 'html' && strpos($this->input->server('HTTP_ACCEPT'), 'xml') === FALSE)
+                        if ($format === 'html' && strpos($this->input->server('HTTP_ACCEPT'), 'xml') === FALSE)
                         {
                             return $format;
                         }
 
                         // If it is truly XML, it wont want any HTML
-                        elseif ($format == 'xml' && strpos($this->input->server('HTTP_ACCEPT'), 'html') === FALSE)
+                        elseif ($format === 'xml' && strpos($this->input->server('HTTP_ACCEPT'), 'html') === FALSE)
                         {
                             return $format;
                         }

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -774,9 +774,12 @@ abstract class REST_Controller extends CI_Controller {
 
             return $matches[1];
         }
+        
+        // Get the format and convert to lowercase
+        $format = strtolower($this->_get_args['format']);
 
         // A format has been passed as an argument in the URL and it is supported
-        if (isset($this->_get_args['format']) && array_key_exists($this->_get_args['format'], $this->_supported_formats))
+        if ($format !== FALSE && isset($this->_supported_formats[$format]))
         {
             return $this->_get_args['format'];
         }

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1286,7 +1286,7 @@ abstract class REST_Controller extends CI_Controller {
      * @access protected
      * @return void
      */
-    public function _parse_query()
+    protected function _parse_query()
     {
         // Declare a variable that will hold the REQUEST_URI
         $request_uri = NULL;

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -774,14 +774,14 @@ abstract class REST_Controller extends CI_Controller {
 
             return $matches[1];
         }
-        
-        // Get the format and convert to lowercase
-        $format = strtolower($this->_get_args['format']);
+
+        // Get the format
+        $format = isset($this->_get_args['format']) ? strtolower($this->_get_args['format']) : NULL;
 
         // A format has been passed as an argument in the URL and it is supported
-        if ($format !== FALSE && isset($this->_supported_formats[$format]))
+        if ($format !== NULL && isset($this->_supported_formats[$format]))
         {
-            return $this->_get_args['format'];
+            return $format;
         }
 
         // Otherwise, check the HTTP_ACCEPT (if it exists and we are allowed)


### PR DESCRIPTION
A new method called $this->query() has been added, that works just the same as it's counterparts e.g. $this->get(), $this->post(), though only for query parameters. This has basically been moved out of $this->_parse_get() into a separate function ($this->_parse_query()), and now means the query parameters can be used regardless of whether it's a GET request (as these were only being being parsed for a GET request).

I have also added class-level constants which denote the popular HTTP status codes for RESTful APIs e.g. REST_Controller::OK or REST_Controller::NOT_FOUND, thus doing away with awful ["magic numbers"](https://en.wikipedia.org/wiki/Magic_number_(programming)#Unnamed_numerical_constants)

There are also a couple of fixes too.