### PR TITLE
API limits can be based on URL, method_name or API_KEY

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -255,7 +255,7 @@ $config['rest_keys_table'] = 'keys';
 |       `id` INT(11) NOT NULL AUTO_INCREMENT,
 |       `key` VARCHAR(40) NOT NULL,
 |       `level` INT(2) NOT NULL,
-|       `ignore_limits` TINY(1) NOT NULL DEFAULT '0',
+|       `ignore_limits` TINYINT(1) NOT NULL DEFAULT '0',
 |       `is_private_key` TINYINT(1)  NOT NULL DEFAULT '0',
 |       `ip_addresses` TEXT NULL DEFAULT NULL,
 |       `date_created` INT(11) NOT NULL,
@@ -410,6 +410,22 @@ $config['rest_logs_json_params'] = FALSE;
 | See application/controllers/api/example.php for examples
 */
 $config['rest_enable_limits'] = FALSE;
+
+/*
+|--------------------------------------------------------------------------
+| REST API Limits method
+|--------------------------------------------------------------------------
+|
+| Specify the method used to limit the API calls
+|
+| Available methods are :
+| $config['rest_limits_method'] = 'API_KEY'; // put a limit per api key
+| $config['rest_limits_method'] = 'METHOD_NAME'; // put a limit on method calls
+| $config['rest_limits_method'] = 'ROUTED_URL';  // put a limit on the routed URL
+|
+*/
+
+$config['rest_limits_method'] = 'ROUTED_URL';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
I rewrote the _check_limit method so It can be configured to the needs of almost everyone.

It solves #397 while being compatible with less restrictive needs.

With
```
$config['rest_limits_method'] = 'API_KEY'; // put a limit per api key
```
limits are based on the api key only
```
$this->methods = ['myAPI_KEY' => ['level' => 0, 'limit' => 1, 'time' => 60 * 60 * 24]];
```

With 
```
$config['rest_limits_method'] = 'METHOD_NAME'; // put a limit on method calls
```
limits are based on the called method
```
$this->methods = ['method_name_get' => ['level' => 0, 'limit' => 1, 'time' => 60 * 60 * 24]];
```

With
```
$config['rest_limits_method'] = 'ROUTED_URL';  // put a limit on the routed URL
```
limits are based on the URL (without the format extension but with the HTTP_METHOD) and the method which is the best option in my opinion
```
$this->methods = ['method_name_get' => ['level' => 0, 'limit' => 1, 'time' => 60 * 60 * 24]];
```