### PR TITLE
Fix for issue #530 Field 'response_code' doesn't have a default value

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -352,7 +352,7 @@ $config['rest_key_name'] = 'X-API-KEY';
 |       `time` INT(11) NOT NULL,
 |       `rtime` FLOAT DEFAULT NULL,
 |       `authorized` VARCHAR(1) NOT NULL,
-|       `response_code` SMALLINT(3) NOT NULL,
+|       `response_code` smallint(3) DEFAULT '0',
 |       PRIMARY KEY (`id`)
 |   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 |


### PR DESCRIPTION
Issue #530 Set the response_code field in the logs table to have a default of '0'.