### PR TITLE
Verify required params

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2106,5 +2106,24 @@ abstract class REST_Controller extends CI_Controller {
             ->get($this->config->item('rest_access_table'))
             ->num_rows() > 0;
     }
+    
+        /**
+     * Check if the requiered paramaters are send to the rest call
+     * 
+     * $params array of parameter names that are required
+     */
+    function verify_required_params($params){
+        
+        foreach ($params as $param){
+            if(!$this->post($param)){
+            $this->response(
+                    array(
+                    "error"=>TRUE,
+                    "message"=>"$param value not set!"
+                ),400);
+        }
+        }
+        
+    }
 
 }


### PR DESCRIPTION
I don't know if there is a easy way to check if required params are in the api call. If not I'm using this but if so let me know how to use it.

Usage in controller:

$this->verify_required_params(array('name','number'));