### PR TITLE
Config file database structure missing field.

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -291,6 +291,7 @@ $config['rest_keys_table'] = 'keys';
 | Default table schema:
 |   CREATE TABLE `keys` (
 |       `id` INT(11) NOT NULL AUTO_INCREMENT,
+|       `user_id` INT(11) NOT NULL,
 |       `key` VARCHAR(40) NOT NULL,
 |       `level` INT(2) NOT NULL,
 |       `ignore_limits` TINYINT(1) NOT NULL DEFAULT '0',


### PR DESCRIPTION
Added missing `user_id` field for `keys` database structure in rest config file.