### PR TITLE
Remove the exit() of REST_Controller->response()

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1419,12 +1419,6 @@ abstract class REST_Controller extends CI_Controller {
            // If no filetype is provided, then there are probably just arguments
            $this->_put_args = $this->input->input_stream();
         }
-
-
-        if(sizeof($this->_put_args) === 0){
-          $this->_parse_post();
-          $this->_put_args = $this->_post_args;
-        }
     }
 
     /**
@@ -1489,11 +1483,6 @@ abstract class REST_Controller extends CI_Controller {
         if ($this->input->method() === 'delete')
         {
             $this->_delete_args = $this->input->input_stream();
-        }
-
-        if(sizeof($this->_delete_args) === 0){
-          $this->_parse_post();
-          $this->_delete_args = $this->_post_args;
         }
     }
 


### PR DESCRIPTION
As described in #476, the `exit()` call in the response function causes php to terminate and, unfortunately, kills phpunit along the way. 

I've replaced the exit by return when needs be. 

I've tested this feature branch with:

- Without authentification
- With API key authentification
- With API key + the three kinds of limits.

Phpunit (with [ci-phpunit-test](https://github.com/Toolwatchapp/ci-phpunit-test)) will work just fine with this refactoring.

M.

  