### PR TITLE
Limit lookup optimization

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -463,8 +463,9 @@ $config['rest_logs_json_params'] = FALSE;
 |       `uri` VARCHAR(255) NOT NULL,
 |       `count` INT(10) NOT NULL,
 |       `hour_started` INT(11) NOT NULL,
-|       `api_key` VARCHAR(40) NOT NULL,
-|       PRIMARY KEY (`id`)
+|       `api_key_id` INT(11) NOT NULL,
+|       PRIMARY KEY (`id`),
+|       FOREIGN KEY (`api_key_id`) REFERENCES `keys`(`id`) ON DELETE CASCADE
 |   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 |
 | To specify the limits within the controller's __construct() method, add per-method

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1419,12 +1419,6 @@ abstract class REST_Controller extends CI_Controller {
            // If no filetype is provided, then there are probably just arguments
            $this->_put_args = $this->input->input_stream();
         }
-
-
-        if(sizeof($this->_put_args) === 0){
-          $this->_parse_post();
-          $this->_put_args = $this->_post_args;
-        }
     }
 
     /**
@@ -1489,11 +1483,6 @@ abstract class REST_Controller extends CI_Controller {
         if ($this->input->method() === 'delete')
         {
             $this->_delete_args = $this->input->input_stream();
-        }
-
-        if(sizeof($this->_delete_args) === 0){
-          $this->_parse_post();
-          $this->_delete_args = $this->_post_args;
         }
     }
 


### PR DESCRIPTION
I noticed that the `_check_limit` function was checking the limit table using the api-key as a String.

Since there is no option to put limits without API key, it'll more efficient to use a foreign key to the key table.

I've modified the `_check_limit` function to use an FK and config file to create the limit table.

M. 