### PR TITLE
In case of json put request parsed body in order to get the parameters.

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1432,6 +1432,9 @@ abstract class REST_Controller extends CI_Controller {
         if ($this->request->format)
         {
             $this->request->body = $this->input->raw_input_stream;
+            if ($this->request->format === 'json') {
+                $this->_put_args = json_decode($this->input->raw_input_stream);                
+            }
         }
         else if ($this->input->method() === 'put')
         {

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1432,8 +1432,9 @@ abstract class REST_Controller extends CI_Controller {
         if ($this->request->format)
         {
             $this->request->body = $this->input->raw_input_stream;
-            if ($this->request->format === 'json') {
-                $this->_put_args = json_decode($this->input->raw_input_stream);                
+            if ($this->request->format === 'json')
+            {
+                $this->_put_args = json_decode($this->input->raw_input_stream);
             }
         }
         else if ($this->input->method() === 'put')


### PR DESCRIPTION
If you are making JSON requests to the server everything is working fine when using POST method, but in case of PUT request no variable is showing up. In fact only url_encoded requests are accepted in PUT request. 

This commit solves the problem in case of JSON request by parsing the body and assigning it to the put_args in order to make it work with Angular2 or other JavaScript requests. 