### PR TITLE
Response code changed

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -660,12 +660,12 @@ abstract class REST_Controller extends CI_Controller {
         }
 
         // Sure it exists, but can they do anything with it?
-        if (method_exists($this, $controller_method) === FALSE)
+        if (!method_exists($this, $controller_method))
         {
             $this->response([
                     $this->config->item('rest_status_field_name') => FALSE,
                     $this->config->item('rest_message_field_name') => $this->lang->line('text_rest_unknown_method')
-                ], self::HTTP_NOT_FOUND);
+                ], self::HTTP_METHOD_NOT_ALLOWED);
         }
 
         // Doing key related stuff? Can only do it if they have a key right?


### PR DESCRIPTION
I think that is better to use 405 as response code in this case. That's because the reason for this error is that the method is not found/allowed. 
It will be good to have separate cases if method is not declared in the controller and when the HTTP method does not match the expected one.
I also purpose to use exclamation mark in the if instead of ```method_exists($this, $controller_method) === FALSE```. It is shorter and since (method_exits())[http://php.net/manual/en/function.method-exists.php] returns boolean, I do not see a problem to do it ;).