### PR TITLE
_check_access() flow change

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -417,6 +417,7 @@ $config['rest_logs_table'] = 'logs';
 |   CREATE TABLE `access` (
 |       `id` INT(11) unsigned NOT NULL AUTO_INCREMENT,
 |       `key` VARCHAR(40) NOT NULL DEFAULT '',
+|       `all_access` TINYINT(1) NOT NULL DEFAULT '0',
 |       `controller` VARCHAR(50) NOT NULL DEFAULT '',
 |       `date_created` DATETIME DEFAULT NULL,
 |       `date_modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2153,6 +2153,16 @@ abstract class REST_Controller extends CI_Controller {
         {
             return TRUE;
         }
+        
+        //check if the key has all_access
+        $accessRow = $this->rest->db
+            ->where('key', $this->rest->key)
+            ->get($this->config->item('rest_access_table'))->row_array();
+        
+        if (!empty($accessRow) && !empty($accessRow['all_access']))
+        {
+        	return TRUE;
+        }
 
         // Fetch controller based on path and controller name
         $controller = implode(


### PR DESCRIPTION
For cases where you want a particular api-key to have access to all controllers, it is better to have a flag to indicate that instead of having a row for each controller in the access table.