### PR TITLE
fix json_encode for integer values

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -403,14 +403,14 @@ class Format {
 
         if (empty($callback) === TRUE)
         {
-            return json_encode($data);
+            return json_encode($data, JSON_NUMERIC_CHECK);
         }
 
         // We only honour a jsonp callback which are valid javascript identifiers
         elseif (preg_match('/^[a-z_\$][a-z0-9\$_]*(\.[a-z_\$][a-z0-9\$_]*)*$/i', $callback))
         {
             // Return the data as encoded json with a callback
-            return $callback.'('.json_encode($data).');';
+            return $callback.'('.json_encode($data, JSON_NUMERIC_CHECK).');';
         }
 
         // An invalid jsonp callback function provided.


### PR DESCRIPTION
without the parameter JSON_NUMERIC_CHECK the json_encode function is ignoring the integer values from a array or database and then the integer values are serialized into a string.