### PR TITLE
fix cross site to option request error

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -646,6 +646,11 @@ abstract class REST_Controller extends CI_Controller {
             {
                 $this->_log_request();
             }
+            
+            // fix cross site to option request error 
+            if($this->request->method == 'options') {
+                exit;
+            }
 
             $this->response([
                     $this->config->item('rest_status_field_name') => FALSE,


### PR DESCRIPTION
cross site request first can use option http method.
but use `keys` authentication, authentication can fail
