### PR TITLE
Code smell, PHP Doc problems, Index methods, and global exception handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 vendor
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog:
 ===========
 
+### UNRELEASED
+* Added support for CodeIgniter controller's index methods (index_GET, index_POST...)
+* Added exceptions handling when the method could not be found
+
 ### 2.7.2
 
 * Added $this->query() in which query parameters can now be obtained regardless of whether a GET request is sent or not

--- a/application/controllers/api/Example.php
+++ b/application/controllers/api/Example.php
@@ -3,6 +3,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 // This can be removed if you use __autoload() in config.php OR use Modular Extensions
+/** @noinspection PhpIncludeInspection */
 require APPPATH . '/libraries/REST_Controller.php';
 
 /**

--- a/application/controllers/api/Key.php
+++ b/application/controllers/api/Key.php
@@ -3,6 +3,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 // This can be removed if you use __autoload() in config.php OR use Modular Extensions
+/** @noinspection PhpIncludeInspection */
 require APPPATH . '/libraries/REST_Controller.php';
 
 /**

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -462,7 +462,7 @@ class Format {
 
     /**
      * @param $data XML string
-     * @return SimpleXMLElement XML element object; otherwise, empty array
+     * @return array XML element object; otherwise, empty array
      */
     protected function _from_xml($data)
     {

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -461,7 +461,7 @@ class Format {
     // INTERNAL FUNCTIONS
 
     /**
-     * @param $data XML string
+     * @param string $data XML string
      * @return array XML element object; otherwise, empty array
      */
     protected function _from_xml($data)
@@ -496,7 +496,7 @@ class Format {
     }
 
     /**
-     * @param $data Encoded json string
+     * @param string $data Encoded json string
      * @return mixed Decoded json string with leading and trailing whitespace removed
      */
     protected function _from_json($data)
@@ -505,7 +505,7 @@ class Format {
     }
 
     /**
-     * @param string Data to unserialized
+     * @param string $data Data to unserialize
      * @return mixed Unserialized data
      */
     protected function _from_serialize($data)
@@ -514,7 +514,7 @@ class Format {
     }
 
     /**
-     * @param $data Data to trim leading and trailing whitespace
+     * @param string $data Data to trim leading and trailing whitespace
      * @return string Data with leading and trailing whitespace removed
      */
     protected function _from_php($data)

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -631,6 +631,11 @@ abstract class REST_Controller extends CI_Controller {
         $object_called = preg_replace('/^(.*)\.(?:'.implode('|', array_keys($this->_supported_formats)).')$/', '$1', $object_called);
 
         $controller_method = $object_called.'_'.$this->request->method;
+	    // Does this method exist? If not, try executing an index method
+	    if (!method_exists($this, $controller_method)) {
+		    $controller_method = "index_" . $this->request->method;
+		    array_unshift($arguments, $object_called);
+	    }
 
         // Do we want to log this method (if allowed by config)?
         $log_method = ! (isset($this->methods[$controller_method]['log']) && $this->methods[$controller_method]['log'] === FALSE);

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -590,7 +590,7 @@ abstract class REST_Controller extends CI_Controller {
      * Checks to see if we have everything we need to run this library.
      *
      * @access protected
-     * @return Exception
+     * @@throws Exception
      */
     protected function preflight_checks()
     {

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -375,7 +375,6 @@ abstract class REST_Controller extends CI_Controller {
      * @access public
      * @param string $config Configuration filename minus the file extension
      * e.g: my_rest.php is passed as 'my_rest'
-     * @return void
      */
     public function __construct($config = 'rest')
     {

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -729,13 +729,8 @@ abstract class REST_Controller extends CI_Controller {
         catch (Exception $ex)
         {
             // If the method doesn't exist, then the error will be caught and an error response shown
-            $this->response([
-                    $this->config->item('rest_status_field_name') => FALSE,
-                    $this->config->item('rest_message_field_name') => [
-                        'classname' => get_class($ex),
-                        'message' => $ex->getMessage()
-                    ]
-                ], self::HTTP_INTERNAL_SERVER_ERROR);
+	        $_error = &load_class('Exceptions', 'core');
+	        $_error->show_exception($ex);
         }
     }
 


### PR DESCRIPTION
- Using PHPStorm's code inspection, I elliminated some problems with PHP Doc, and what they call "Code Smell"
- Added support for CodeIgniter controller's index methods (index_GET, index_POST...)
  - You can now create a controller, ex `countries`, and have a method `index_get()` such that a request to: `/countries` will trigger it. Also, you can have `index_get($code)` so `/countris/US` will trigger it
  - This supports REST standards. `/countries` can list, can get, can post, can put, can patch, and can delete
- Added exceptions handling when the method could not be found
  - My suggested exceptions handler was added, but I take it back, and instead I added a usage of global CI_Exceptions/MY_Exceptions handler
