### PR TITLE
REST_Controller auth override fix

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1993,7 +1993,7 @@ abstract class REST_Controller extends \CI_Controller {
         // Check if the user is logged into the system
         if ($this->_check_login($username, $password) === FALSE)
         {
-            $this->_force_login();
+            $this->_force_login('', 'auth');
         }
     }
 
@@ -2025,7 +2025,7 @@ abstract class REST_Controller extends \CI_Controller {
         // again if none given or if the user enters wrong auth information
         if (empty($digest_string))
         {
-            $this->_force_login($unique_id);
+            $this->_force_login($unique_id, 'digest');
         }
 
         // We need to retrieve authentication data from the $digest_string variable
@@ -2037,7 +2037,7 @@ abstract class REST_Controller extends \CI_Controller {
         $username = $this->_check_login($digest['username'], TRUE);
         if (array_key_exists('username', $digest) === FALSE || $username === FALSE)
         {
-            $this->_force_login($unique_id);
+            $this->_force_login($unique_id, 'digest');
         }
 
         $md5 = md5(strtoupper($this->request->method).':'.$digest['uri']);
@@ -2112,9 +2112,9 @@ abstract class REST_Controller extends \CI_Controller {
      * each time
      * @return void
      */
-    protected function _force_login($nonce = '')
+    protected function _force_login($nonce = '', $rest_auth = '')
     {
-        $rest_auth = $this->config->item('rest_auth');
+        
         $rest_realm = $this->config->item('rest_realm');
         if (strtolower($rest_auth) === 'basic')
         {


### PR DESCRIPTION
_prepare_basic_auth and _prepare_digest_auth methods should pass authentication type to force_login method. Otherwise auth overriding doesn't work properly.