### PR TITLE
Fetching the request body in PUT requests

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -1469,7 +1469,6 @@ abstract class REST_Controller extends \CI_Controller {
     {
         if ($this->request->format)
         {
-            $this->request->body = $this->input->raw_input_stream;
             if ($this->request->format === 'json')
             {
                 $this->_put_args = json_decode($this->input->raw_input_stream);
@@ -1480,6 +1479,8 @@ abstract class REST_Controller extends \CI_Controller {
            // If no file type is provided, then there are probably just arguments
            $this->_put_args = $this->input->input_stream();
         }
+
+        $this->request->body = $this->input->raw_input_stream;
     }
 
     /**


### PR DESCRIPTION
In PUT requests where the payload does not have a defined name (e.g JSON object) the request body should get the raw input stream.