### PR TITLE
Insert comma and then a space in allowed headers and methods.

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2229,8 +2229,8 @@ abstract class REST_Controller extends CI_Controller {
     protected function _check_cors()
     {
         // Convert the config items into strings
-        $allowed_headers = implode(' ,', $this->config->item('allowed_cors_headers'));
-        $allowed_methods = implode(' ,', $this->config->item('allowed_cors_methods'));
+        $allowed_headers = implode(', ', $this->config->item('allowed_cors_headers'));
+        $allowed_methods = implode(', ', $this->config->item('allowed_cors_methods'));
 
         // If we want to allow any domain to access the API
         if ($this->config->item('allow_any_cors_domain') === TRUE)


### PR DESCRIPTION
Inserting a space first and then a comma seems wrong to me. Was this intended?

Why `Origin ,X-Requested-With ,Content-Type ,Accept ,Access-Control-Request-Method` instead of `Origin, X-Requested-With, Content-Type, Accept, Access-Control-Request-Method`?