### PR TITLE
Using composer to autoload Format library.

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -1,4 +1,5 @@
 <?php
+namespace Restserver\Libraries;
 
 defined('BASEPATH') OR exit('No direct script access allowed');
 

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -396,7 +396,8 @@ abstract class REST_Controller extends CI_Controller {
         $this->load->config($config);
 
         // At present the library is bundled with REST_Controller 2.5+, but will eventually be part of CodeIgniter (no citation)
-        $this->load->library('format');
+	//$this->load->library('format');
+	$this->format = new Format(); // Use composer to load library
 
         // Determine supported output formats from configuration
         $supported_formats = $this->config->item('rest_supported_formats');


### PR DESCRIPTION
Without the need to copy Format.php to application/libraries folder.