### PR TITLE
Force validation 

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -138,6 +138,7 @@ $config['auth_source'] = 'ldap';
 |
 */
 $config['allow_auth_and_keys'] = TRUE;
+$config['strict_api_and_auth'] = TRUE; // force the use of both api and auth before a valid api request is made
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Force the use of api key and authentication if selected in the config.
This also resolves the issue with basic authentication being accepted with every request.