### PR TITLE
Added csv output encoding conversion from UTF-8 to UTF-16LE

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -378,6 +378,9 @@ class Format {
 
         // Close the handle
         fclose($handle);
+        
+        // Convert UTF-8 encoding to UTF-16LE which is supported by MS Excel
+        $csv = mb_convert_encoding($csv, 'UTF-16LE', 'UTF-8');
 
         return $csv;
     }


### PR DESCRIPTION
As per this answer: https://stackoverflow.com/questions/4348802/how-can-i-output-a-utf-8-csv-in-php-that-excel-will-read-properly/16766198#16766198

If csv content encoding is not converted, special characters will not work in Microsoft Excel (but will work eg. in Notepad++). After encoding conversion MS Excel will show special characters properly.

(My first PR ever so hope I did everything by the book!)