### PR TITLE
Migrations

### DIFF
--- a/application/helpers/db_helper.php
+++ b/application/helpers/db_helper.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+if ( ! function_exists('add_foreign_key'))
+{
+	/**
+	 * @param string $table       Table name
+	 * @param string $foreign_key Collumn name having the Foreign Key
+	 * @param string $references  Table and column reference. Ex: users(id)
+	 * @param string $on_delete   RESTRICT, NO ACTION, CASCADE, SET NULL, SET DEFAULT
+	 * @param string $on_update   RESTRICT, NO ACTION, CASCADE, SET NULL, SET DEFAULT
+	 *
+	 * @return string SQL command
+	 */
+	function add_foreign_key($table, $foreign_key, $references, $on_delete = 'RESTRICT', $on_update = 'RESTRICT')
+	{
+		$references = explode('(', str_replace(')', '', str_replace('`', '', $references)));
+
+		return "ALTER TABLE `{$table}` ADD CONSTRAINT `{$table}_{$foreign_key}_fk` FOREIGN KEY (`{$foreign_key}`) REFERENCES `{$references[0]}`(`{$references[1]}`) ON DELETE {$on_delete} ON UPDATE {$on_update}";
+	}
+}
+
+if ( ! function_exists('drop_foreign_key'))
+{
+	/**
+	 * @param string $table       Table name
+	 * @param string $foreign_key Collumn name having the Foreign Key
+	 *
+	 * @return string SQL command
+	 */
+	function drop_foreign_key($table, $foreign_key)
+	{
+		return "ALTER TABLE `{$table}` DROP FOREIGN KEY `{$table}_{$foreign_key}_fk`";
+	}
+}
+
+if ( ! function_exists('add_trigger'))
+{
+	/**
+	 * @param string $trigger_name Trigger name
+	 * @param string $table        Table name
+	 * @param string $statement    Command to run
+	 * @param string $time         BEFORE or AFTER
+	 * @param string $event        INSERT, UPDATE or DELETE
+	 * @param string $type         FOR EACH ROW [FOLLOWS|PRECEDES]
+	 *
+	 * @return string SQL Command
+	 */
+	function add_trigger($trigger_name, $table, $statement, $time = 'BEFORE', $event = 'INSERT', $type = 'FOR EACH ROW')
+	{
+		return 'DELIMITER ;;' . PHP_EOL . "CREATE TRIGGER `{$trigger_name}` {$time} {$event} ON `{$table}` {$type}" . PHP_EOL . 'BEGIN' . PHP_EOL . $statement . PHP_EOL . 'END;' . PHP_EOL . 'DELIMITER ;;';
+	}
+}
+
+if ( ! function_exists('drop_trigger'))
+{
+	/**
+	 * @param string $trigger_name Trigger name
+	 *
+	 * @return string SQL Command
+	 */
+	function drop_trigger($trigger_name)
+	{
+		return "DROP TRIGGER {$trigger_name};";
+	}
+}

--- a/application/helpers/index.html
+++ b/application/helpers/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/language/portuguese-brazilian/rest_controller_lang.php
+++ b/application/language/portuguese-brazilian/rest_controller_lang.php
@@ -13,6 +13,6 @@ $lang['text_rest_ajax_only'] = 'Apenas chamadas AJAX são permitidas';
 $lang['text_rest_api_key_unauthorized'] = 'Esta chave da API não tem acesso ao controller solicitado';
 $lang['text_rest_api_key_permissions'] = 'Esta chave da API não tem permissões suficientes';
 $lang['text_rest_api_key_time_limit'] = 'Esta chave da API já atingiu o tempo limite para este método';
-$lang['text_rest_ip_address_time_limit'] = 'This IP Address has reached the time limit for this method';//todo translate
+$lang['text_rest_ip_address_time_limit'] = 'Este Endereço IP atingiu o limite de tempo para este método';
 $lang['text_rest_unknown_method'] = 'Método desconhecido';
 $lang['text_rest_unsupported'] = 'Sem suporte para este protocolo';

--- a/application/language/portuguese-brazilian/rest_controller_lang.php
+++ b/application/language/portuguese-brazilian/rest_controller_lang.php
@@ -13,6 +13,6 @@ $lang['text_rest_ajax_only'] = 'Apenas chamadas AJAX são permitidas';
 $lang['text_rest_api_key_unauthorized'] = 'Esta chave da API não tem acesso ao controller solicitado';
 $lang['text_rest_api_key_permissions'] = 'Esta chave da API não tem permissões suficientes';
 $lang['text_rest_api_key_time_limit'] = 'Esta chave da API já atingiu o tempo limite para este método';
-$lang['text_rest_ip_address_time_limit'] = 'Este Endereço IP atingiu o limite de tempo para este método';
+$lang['text_rest_ip_address_time_limit'] = 'This IP Address has reached the time limit for this method';//todo translate
 $lang['text_rest_unknown_method'] = 'Método desconhecido';
 $lang['text_rest_unsupported'] = 'Sem suporte para este protocolo';

--- a/application/migrations/20170706025420_create_table_users.php
+++ b/application/migrations/20170706025420_create_table_users.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_create_table_users
+ *
+ * @property CI_DB_forge         $dbforge
+ * @property CI_DB_query_builder $db
+ */
+class Migration_create_table_users extends CI_Migration {
+
+
+	protected $table = 'users';
+
+
+	public function up()
+	{
+		$fields = array(
+			'id'         => [
+				'type'           => 'INT(11)',
+				'auto_increment' => TRUE,
+				'unsigned'       => TRUE,
+			],
+			'email'      => [
+				'type'   => 'VARCHAR(255)',
+				'unique' => TRUE,
+			],
+			'password'   => [
+				'type' => 'VARCHAR(64)',
+			],
+			'firstname'  => [
+				'type' => 'VARCHAR(32)',
+			],
+			'lastname'   => [
+				'type' => 'VARCHAR(32)',
+			],
+			'created_at' => [
+				'type' => 'DATETIME',
+			],
+		);
+		$this->dbforge->add_field($fields);
+		$this->dbforge->add_key('id', TRUE);
+		$this->dbforge->create_table($this->table, TRUE);
+
+		/*for ($i = 1; $i <= 100; $i++)
+		{
+			$this->db->insert($this->table, [
+				'email'      => "user-{$i}@mail.com",
+				'password'   => password_hash('codeigniter', PASSWORD_DEFAULT),
+				'firstname'  => "Firstname {$i}",
+				'lastname'   => "Lastname {$i}",
+				'created_at' => date('Y-' . rand(1, 12) . '-' . rand(1, 28) . ' H:i:s'),
+			]);
+		}*/
+	}
+
+
+	public function down()
+	{
+		if ($this->db->table_exists($this->table))
+		{
+			$this->dbforge->drop_table($this->table);
+		}
+	}
+
+}

--- a/application/migrations/20170706025420_create_table_users.php
+++ b/application/migrations/20170706025420_create_table_users.php
@@ -45,7 +45,7 @@ class Migration_create_table_users extends CI_Migration {
 		$this->dbforge->add_key('id', TRUE);
 		$this->dbforge->create_table($this->table, TRUE);
 
-		/*for ($i = 1; $i <= 100; $i++)
+		for ($i = 1; $i <= 100; $i++)
 		{
 			$this->db->insert($this->table, [
 				'email'      => "user-{$i}@mail.com",
@@ -54,7 +54,7 @@ class Migration_create_table_users extends CI_Migration {
 				'lastname'   => "Lastname {$i}",
 				'created_at' => date('Y-' . rand(1, 12) . '-' . rand(1, 28) . ' H:i:s'),
 			]);
-		}*/
+		}
 	}
 
 
@@ -62,8 +62,8 @@ class Migration_create_table_users extends CI_Migration {
 	{
 		if ($this->db->table_exists($this->table))
 		{
-			$this->dbforge->drop_table($this->table);
 		}
+		$this->dbforge->drop_table($this->table);
 	}
 
 }

--- a/application/migrations/20170706025420_create_table_users.php
+++ b/application/migrations/20170706025420_create_table_users.php
@@ -45,7 +45,7 @@ class Migration_create_table_users extends CI_Migration {
 		$this->dbforge->add_key('id', TRUE);
 		$this->dbforge->create_table($this->table, TRUE);
 
-		for ($i = 1; $i <= 100; $i++)
+		/*for ($i = 1; $i <= 100; $i++)
 		{
 			$this->db->insert($this->table, [
 				'email'      => "user-{$i}@mail.com",
@@ -54,7 +54,7 @@ class Migration_create_table_users extends CI_Migration {
 				'lastname'   => "Lastname {$i}",
 				'created_at' => date('Y-' . rand(1, 12) . '-' . rand(1, 28) . ' H:i:s'),
 			]);
-		}
+		}*/
 	}
 
 
@@ -62,8 +62,8 @@ class Migration_create_table_users extends CI_Migration {
 	{
 		if ($this->db->table_exists($this->table))
 		{
+			$this->dbforge->drop_table($this->table);
 		}
-		$this->dbforge->drop_table($this->table);
 	}
 
 }

--- a/application/migrations/20170706030520_create_table_api_keys.php
+++ b/application/migrations/20170706030520_create_table_api_keys.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_create_table_api_keys
+ *
+ * @property CI_DB_forge         $dbforge
+ * @property CI_DB_query_builder $db
+ */
+class Migration_create_table_api_keys extends CI_Migration {
+
+
+	public function up()
+	{
+		$table = config_item('rest_keys_table');
+		$fields = array(
+			'id'                           => [
+				'type'           => 'INT(11)',
+				'auto_increment' => TRUE,
+				'unsigned'       => TRUE,
+			],
+			'user_id'                      => [
+				'type'     => 'INT(11)',
+				'unsigned' => TRUE,
+			],
+			config_item('rest_key_column') => [
+				'type'   => 'VARCHAR(' . config_item('rest_key_length') . ')',
+				'unique' => TRUE,
+			],
+			'level'                        => [
+				'type' => 'INT(2)',
+			],
+			'ignore_limits'                => [
+				'type'    => 'TINYINT(1)',
+				'default' => 0,
+			],
+			'is_private_key'               => [
+				'type'    => 'TINYINT(1)',
+				'default' => 0,
+			],
+			'ip_addresses'                 => [
+				'type' => 'TEXT',
+				'null' => TRUE,
+			],
+			'date_created'                 => [
+				'type' => 'INT(11)',
+			],
+		);
+		$this->dbforge->add_field($fields);
+		$this->dbforge->add_key('id', TRUE);
+		$this->dbforge->create_table($table);
+		$this->db->query(add_foreign_key($table, 'user_id', 'users(id)', 'CASCADE', 'CASCADE'));
+	}
+
+
+	public function down()
+	{
+		$table = config_item('rest_key_column');
+		if ($this->db->table_exists($table))
+		{
+			$this->db->query(drop_foreign_key($table, 'user_id'));
+			$this->dbforge->drop_table($table);
+		}
+	}
+
+}

--- a/application/migrations/20170706031435_create_table_api_logs.php
+++ b/application/migrations/20170706031435_create_table_api_logs.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_create_table_api_logs
+ *
+ * @property CI_DB_forge         $dbforge
+ * @property CI_DB_query_builder $db
+ */
+class Migration_create_table_api_logs extends CI_Migration {
+
+
+	public function up()
+	{
+		$table = config_item('rest_logs_table');
+		$fields = array(
+			'id'            => [
+				'type'           => 'INT(11)',
+				'auto_increment' => TRUE,
+				'unsigned'       => TRUE,
+			],
+			'api_key'       => [
+				'type' => 'VARCHAR(' . config_item('rest_key_length') . ')',
+			],
+			'uri'           => [
+				'type' => 'VARCHAR(255)',
+			],
+			'method'        => [
+				'type' => 'ENUM("get","post","options","put","patch","delete")',
+			],
+			'params'        => [
+				'type' => 'TEXT',
+				'null' => TRUE,
+			],
+			'ip_address'    => [
+				'type' => 'VARCHAR(45)',
+			],
+			'time'          => [
+				'type' => 'INT(11)',
+			],
+			'rtime'         => [
+				'type' => 'FLOAT',
+				'null' => TRUE,
+			],
+			'authorized'    => [
+				'type' => 'VARCHAR(1)',
+			],
+			'response_code' => [
+				'type'    => 'SMALLINT(3)',
+				'null'    => TRUE,
+				'default' => 0,
+			],
+		);
+		$this->dbforge->add_field($fields);
+		$this->dbforge->add_key('id', TRUE);
+		$this->dbforge->create_table($table);
+		/*$this->db->query(add_foreign_key($table, 'api_key',
+			config_item('rest_keys_table') . '(' . config_item('rest_key_column') . ')', 'CASCADE', 'CASCADE'));*/
+	}
+
+
+	public function down()
+	{
+		$table = config_item('rest_logs_table');
+		if ($this->db->table_exists($table))
+		{
+			// $this->db->query(drop_foreign_key($table, 'api_key'));
+			$this->dbforge->drop_table($table);
+		}
+	}
+
+}

--- a/application/migrations/20170706032133_create_table_api_access.php
+++ b/application/migrations/20170706032133_create_table_api_access.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_create_table_api_access
+ *
+ * @property CI_DB_forge         $dbforge
+ * @property CI_DB_query_builder $db
+ */
+class Migration_create_table_api_access extends CI_Migration {
+
+
+	public function up()
+	{
+		$table = config_item('rest_access_table');
+		$fields = array(
+			'id'            => [
+				'type'           => 'INT(11)',
+				'auto_increment' => TRUE,
+				'unsigned'       => TRUE,
+			],
+			'key'           => [
+				'type' => 'VARCHAR(' . config_item('rest_key_length') . ')',
+			],
+			'all_access'    => [
+				'type'    => 'TINYINT(1)',
+				'default' => 0,
+			],
+			'controller'    => [
+				'type' => 'VARCHAR(50)',
+			],
+			'date_created'  => [
+				'type' => 'DATETIME',
+				'null' => TRUE,
+			],
+			'date_modified' => [
+				'type' => 'TIMESTAMP',
+			],
+		);
+		$this->dbforge->add_field($fields);
+		$this->dbforge->add_key('id', TRUE);
+		$this->dbforge->add_key('controller');
+		$this->dbforge->create_table($table);
+		$this->db->query(add_foreign_key($table, 'key',
+			config_item('rest_keys_table') . '(' . config_item('rest_key_column') . ')', 'CASCADE', 'CASCADE'));
+	}
+
+
+	public function down()
+	{
+		$table = config_item('rest_access_table');
+		if ($this->db->table_exists($table))
+		{
+			$this->db->query(drop_foreign_key($table, 'key'));
+			$this->dbforge->drop_table($table);
+		}
+	}
+
+}

--- a/application/migrations/20170706032825_create_table_api_limits.php
+++ b/application/migrations/20170706032825_create_table_api_limits.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author   Natan Felles <natanfelles@gmail.com>
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_create_table_api_limits
+ *
+ * @property CI_DB_forge         $dbforge
+ * @property CI_DB_query_builder $db
+ */
+class Migration_create_table_api_limits extends CI_Migration {
+
+
+	public function up()
+	{
+		$table = config_item('rest_limits_table');
+		$fields = array(
+			'id'           => [
+				'type'           => 'INT(11)',
+				'auto_increment' => TRUE,
+				'unsigned'       => TRUE,
+			],
+			'api_key'      => [
+				'type' => 'VARCHAR(' . config_item('rest_key_length') . ')',
+			],
+			'uri'          => [
+				'type' => 'VARCHAR(255)',
+			],
+			'count'        => [
+				'type' => 'INT(10)',
+			],
+			'hour_started' => [
+				'type' => 'INT(11)',
+			],
+		);
+		$this->dbforge->add_field($fields);
+		$this->dbforge->add_key('id', TRUE);
+		$this->dbforge->add_key('uri');
+		$this->dbforge->create_table($table);
+		$this->db->query(add_foreign_key($table, 'api_key',
+			config_item('rest_keys_table') . '(' . config_item('rest_key_column') . ')', 'CASCADE', 'CASCADE'));
+	}
+
+
+	public function down()
+	{
+		$table = config_item('rest_limits_table');
+		if ($this->db->table_exists($table))
+		{
+			$this->db->query(drop_foreign_key($table, 'api_key'));
+			$this->dbforge->drop_table($table);
+		}
+	}
+
+}

--- a/application/migrations/index.html
+++ b/application/migrations/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Add InnoDB Relational Tables with Migrations.

The `db_helper` must be loaded to use Foreign Keys in migrations.

If you accept this PR, can add a info in the README.md or I created a simple controller to do the migration, but is not in the PR. I can add if necessary.

Sorry for the unnecessary commits. I added a wrong file.

