### PR TITLE
Fix: A Database Error Occurred when update logs 

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2174,6 +2174,10 @@ abstract class REST_Controller extends CI_Controller {
      */
     protected function _log_access_time()
     {
+        if($this->_insert_id == ''){
+            return false;
+        }
+
         $payload['rtime'] = $this->_end_rtime - $this->_start_rtime;
 
         return $this->rest->db->update(
@@ -2192,6 +2196,10 @@ abstract class REST_Controller extends CI_Controller {
      */
     protected function _log_response_code($http_code)
     {
+        if($this->_insert_id == ''){
+            return false;
+        }
+
         $payload['response_code'] = $http_code;
 
         return $this->rest->db->update(


### PR DESCRIPTION

Access to non-existent controllers and methods should not update request time and request methods

> A Database Error Occurred
> 
> Error Number: 22P02/7
> 
> ERROR: invalid input syntax for integer: "" LINE 2: WHERE "id" = '' ^
> 
> UPDATE "api_logs" SET "response_code" = 404 WHERE "id" = ''
> 
> Filename: third_party/restserver/libraries/REST_Controller.php
> 
> Line Number: 2208