### PR TITLE
special chars encoding

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -406,21 +406,21 @@ class Format {
 
         if (empty($callback) === TRUE)
         {
-            return json_encode($data);
+            return json_encode($data, JSON_UNESCAPED_UNICODE);
         }
 
         // We only honour a jsonp callback which are valid javascript identifiers
         elseif (preg_match('/^[a-z_\$][a-z0-9\$_]*(\.[a-z_\$][a-z0-9\$_]*)*$/i', $callback))
         {
             // Return the data as encoded json with a callback
-            return $callback.'('.json_encode($data).');';
+            return $callback.'('.json_encode($data, JSON_UNESCAPED_UNICODE).');';
         }
 
         // An invalid jsonp callback function provided.
         // Though I don't believe this should be hardcoded here
         $data['warning'] = 'INVALID JSONP CALLBACK: '.$callback;
 
-        return json_encode($data);
+        return json_encode($data, JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
Special chars, such as "ç" and "ã", that are abundant in my language (portuguese) were being transformed into strange things. with this change, they're showing up just right...