### PR TITLE
bugfix: fatal error if check_cors and rest_enable_logging are both enabled

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2336,6 +2336,11 @@ abstract class REST_Controller extends CI_Controller {
         // If the request HTTP method is 'OPTIONS', kill the response and send it to the client
         if ($this->input->method() === 'options')
         {
+            // Load DB if needed for logging
+            if (!isset($this->rest->db) && $this->config->item('rest_enable_logging'))
+            {
+                $this->rest->db = $this->load->database($this->config->item('rest_database_group'), TRUE);
+            }
             exit;
         }
     }


### PR DESCRIPTION
If the `check_cors` and `rest_enable_logging` options are both enabled, an OPTIONS request will cause a fatal error:

1. the `_check_cors` function will end with an `exit` statement;
2. the class destructor will try to write to the log table;
3. however, the database class is not yet loaded at this point.

In this fix, `_check_cors` will load the database if necessary before `exit`.