### PR TITLE
Add config to force CORS pre-flight headers to be included

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -612,6 +612,10 @@ $config['allowed_cors_origins'] = [];
 |
 | If using CORS checks, always include the headers and values specified here 
 | in the OPTIONS client preflight.
+| Example:
+| $config['forced_cors_headers'] = [
+|   'Access-Control-Allow-Credentials' => 'true'
+| ];
 |
 | Added because of how Sencha Ext JS framework requires the header
 | Access-Control-Allow-Credentials to be set to true to allow the use of
@@ -620,6 +624,4 @@ $config['allowed_cors_origins'] = [];
 | http://docs.sencha.com/extjs/6.5.2/classic/Ext.data.proxy.Rest.html#cfg-withCredentials
 |
 */
-$config['forced_cors_headers'] = [
-  'Access-Control-Allow-Credentials' => 'true'
-];
+$config['forced_cors_headers'] = [];

--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -604,3 +604,22 @@ $config['allow_any_cors_domain'] = FALSE;
 |
 */
 $config['allowed_cors_origins'] = [];
+
+/*
+|--------------------------------------------------------------------------
+| CORS Forced Headers
+|--------------------------------------------------------------------------
+|
+| If using CORS checks, always include the headers and values specified here 
+| in the OPTIONS client preflight.
+|
+| Added because of how Sencha Ext JS framework requires the header
+| Access-Control-Allow-Credentials to be set to true to allow the use of
+| credentials in the REST Proxy. 
+| See documentation here:
+| http://docs.sencha.com/extjs/6.5.2/classic/Ext.data.proxy.Rest.html#cfg-withCredentials
+|
+*/
+$config['forced_cors_headers'] = [
+  'Access-Control-Allow-Credentials' => 'true'
+];

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2333,6 +2333,15 @@ abstract class REST_Controller extends CI_Controller {
             }
         }
 
+        // If there are headers that should be forced in the CORS check, add them now
+        if (is_array($this->config->item('forced_cors_headers')))
+        {
+            foreach ($this->config->item('forced_cors_headers') as $header => $value)
+            {
+                header($header . ': ' . $value);
+            }
+        }
+
         // If the request HTTP method is 'OPTIONS', kill the response and send it to the client
         if ($this->input->method() === 'options')
         {


### PR DESCRIPTION
My front-end framework (Sencha Ext JS) requires the server to set the header Access-Control-Allow-Credentials to true if using a REST Proxy. Added a setting to the config file to allow this.