### PR TITLE
load rest config, correct missing vars - Migrations (#820)

### DIFF
--- a/application/migrations/20170706030520_create_table_api_keys.php
+++ b/application/migrations/20170706030520_create_table_api_keys.php
@@ -15,6 +15,7 @@ class Migration_create_table_api_keys extends CI_Migration {
 
 	public function up()
 	{
+		$this->config->load('rest');
 		$table = config_item('rest_keys_table');
 		$fields = array(
 			'id'                           => [

--- a/application/migrations/20170706031435_create_table_api_logs.php
+++ b/application/migrations/20170706031435_create_table_api_logs.php
@@ -15,6 +15,7 @@ class Migration_create_table_api_logs extends CI_Migration {
 
 	public function up()
 	{
+		$this->config->load('rest');
 		$table = config_item('rest_logs_table');
 		$fields = array(
 			'id'            => [

--- a/application/migrations/20170706032133_create_table_api_access.php
+++ b/application/migrations/20170706032133_create_table_api_access.php
@@ -15,6 +15,7 @@ class Migration_create_table_api_access extends CI_Migration {
 
 	public function up()
 	{
+		$this->config->load('rest');
 		$table = config_item('rest_access_table');
 		$fields = array(
 			'id'            => [

--- a/application/migrations/20170706032825_create_table_api_limits.php
+++ b/application/migrations/20170706032825_create_table_api_limits.php
@@ -15,6 +15,7 @@ class Migration_create_table_api_limits extends CI_Migration {
 
 	public function up()
 	{
+		$this->config->load('rest');
 		$table = config_item('rest_limits_table');
 		$fields = array(
 			'id'           => [


### PR DESCRIPTION
Setting up a Codeigniter Migration the "rest" config needs to be loaded so the config variables are properly loaded.