### PR TITLE
Move output format detection upwards

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -507,6 +507,12 @@ abstract class REST_Controller extends CI_Controller {
             $this->{'_'.$this->request->method.'_args'} = [];
         }
 
+        // Which format should the data be returned in?
+        $this->response->format = $this->_detect_output_format();
+
+        // Which language should the data be returned in?
+        $this->response->lang = $this->_detect_lang();
+
         // Now we know all about our request, let's try and parse the body if it exists
         if ($this->request->format && $this->request->body)
         {
@@ -530,12 +536,6 @@ abstract class REST_Controller extends CI_Controller {
             $this->_delete_args,
             $this->{'_'.$this->request->method.'_args'}
         );
-
-        // Which format should the data be returned in?
-        $this->response->format = $this->_detect_output_format();
-
-        // Which language should the data be returned in?
-        $this->response->lang = $this->_detect_lang();
 
         // Extend this function to apply additional checking early on in the process
         $this->early_checks();


### PR DESCRIPTION
Move output format detection upwards,
to allow responses earlier:

As I have added a custom format via `as_*`, `_from_*` as subclass (#946), I want to realize error handling.
Therefore output must already be possible, when Format::factory is run.