### PR TITLE
QUICKFIX Continue Returns Response

### DIFF
--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -748,7 +748,19 @@ trait REST_Controller {
             }
             else
             {
-                ob_end_flush();
+                if (is_callable('fastcgi_finish_request')) 
+                {
+                    // Terminates connection and returns response to client on PHP-FPM.
+                    $this->output->_display();
+                    ob_end_flush();
+                    fastcgi_finish_request();
+                    ignore_user_abort(true);
+                }
+                else
+                {
+                    // Legacy compatibility.
+                    ob_end_flush();
+                }
             }
 
             // Otherwise dump the output automatically


### PR DESCRIPTION
Fixes issue #1023 
The added lines returns the response to the client and allows code to continue executing. 

`ob_end_flush; ` does not actually work correctly according to https://stackoverflow.com/questions/10579116/how-to-flush-data-to-browser-but-continue-executing 
It is kept for legacy compatibility and to prevent regressions.