### PR TITLE
Optional uppercase for index_get, index_post, etc.

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -56,6 +56,21 @@ $config['rest_supported_formats'] = [
 
 /*
 |--------------------------------------------------------------------------
+| REST HTTP Verbs as Capslock
+|--------------------------------------------------------------------------
+|
+| Turn on to have the HTTP verbs being capslock, e.g `index_GET`, `index_POST`.
+| Turn off to have them lowercase, the example being `index_get`, `index_post`.
+|
+| Using capslock makes it easy to read as HTTP verbs, but might clash with your coding standart.
+| Therefore the default is lowercase, `false`.
+|
+*/
+$config['rest_http_verbs_capslock'] = false;
+
+
+/*
+|--------------------------------------------------------------------------
 | REST Status Field Name
 |--------------------------------------------------------------------------
 |

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -547,8 +547,9 @@ trait REST_Controller {
 
         // Remove the supported format from the function name e.g. index.json => index
         $object_called = preg_replace('/^(.*)\.(?:'.implode('|', array_keys($this->_supported_formats)).')$/', '$1', $object_called);
-
-        $controller_method = $object_called.'_'.$this->request->method;
+        
+        $method_suffix = $this->config->item('rest_http_verbs_capslock') === true ? strtoupper($this->request->method) : $this->request->method)
+        $controller_method = $object_called.'_'.$method_suffix;
         // Does this method exist? If not, try executing an index method
         if (!method_exists($this, $controller_method)) {
             $controller_method = "index_" . $this->request->method;


### PR DESCRIPTION
This change request allows to change a config option to have uppercase HTTP verbs at the end of called methods.
This is added for increased readability, as it makes it easer to distinguish between the http method and the actual function name.

`set_data_get` vs. `get_data_GET` basically.

This change might not be for everyone, so I added it behind config option, which defaults to the old behaviour.