### PR TITLE
Fixes response code constants bug

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -562,7 +562,7 @@ class RestController extends \CI_Controller {
             $this->response([
                 $this->config->item('rest_status_field_name') => FALSE,
                 $this->config->item('rest_message_field_name') => $this->lang->line('text_rest_api_key_unauthorized')
-            ], HTTP_UNAUTHORIZED);
+            ], $this::HTTP_UNAUTHORIZED);
         }
 
         // Sure it exists, but can they do anything with it?
@@ -581,7 +581,7 @@ class RestController extends \CI_Controller {
             if ($this->config->item('rest_enable_limits') && $this->_check_limit($controller_method) === FALSE)
             {
                 $response = [$this->config->item('rest_status_field_name') => FALSE, $this->config->item('rest_message_field_name') => $this->lang->line('text_rest_api_key_time_limit')];
-                $this->response($response, HTTP_UNAUTHORIZED);
+                $this->response($response, $this::HTTP_UNAUTHORIZED);
             }
 
             // If no level is set use 0, they probably aren't using permissions
@@ -598,7 +598,7 @@ class RestController extends \CI_Controller {
             {
                 // They don't have good enough perms
                 $response = [$this->config->item('rest_status_field_name') => FALSE, $this->config->item('rest_message_field_name') => $this->lang->line('text_rest_api_key_permissions')];
-                $this->response($response, HTTP_UNAUTHORIZED);
+                $this->response($response, $this::HTTP_UNAUTHORIZED);
             }
         }
 
@@ -606,7 +606,7 @@ class RestController extends \CI_Controller {
         elseif ($this->config->item('rest_limits_method') == "IP_ADDRESS" && $this->config->item('rest_enable_limits') && $this->_check_limit($controller_method) === FALSE)
         {
             $response = [$this->config->item('rest_status_field_name') => FALSE, $this->config->item('rest_message_field_name') => $this->lang->line('text_rest_ip_address_time_limit')];
-            $this->response($response, HTTP_UNAUTHORIZED);
+            $this->response($response, $this::HTTP_UNAUTHORIZED);
         }
 
         // No key stuff, but record that stuff is happening
@@ -662,7 +662,7 @@ class RestController extends \CI_Controller {
             // If data is NULL and no HTTP status code provided, then display, error and exit
             if ($data === NULL && $http_code === NULL)
             {
-                $http_code = HTTP_NOT_FOUND;
+                $http_code = $this::HTTP_NOT_FOUND;
             }
 
             // If data is not NULL and a HTTP status code provided, then continue
@@ -698,7 +698,7 @@ class RestController extends \CI_Controller {
             // If not greater than zero, then set the HTTP status code as 200 by default
             // Though perhaps 500 should be set instead, for the developer not passing a
             // correct HTTP status code
-            $http_code > 0 || $http_code = HTTP_OK;
+            $http_code > 0 || $http_code = $this::HTTP_OK;
 
             $this->output->set_status_header($http_code);
 


### PR DESCRIPTION
Fix bug Use of undefined constant HTTP_OK - assumed 'HTTP_OK ',
when the response code is not sent in the response function
