### PR TITLE
Fix digest authentication

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -1782,12 +1782,13 @@ class RestController extends \CI_Controller
         $digest = (empty($matches[1]) || empty($matches[2])) ? [] : array_combine($matches[1], $matches[2]);
 
         // For digest authentication the library function should return already stored md5(username:restrealm:password) for that username see rest.php::auth_library_function config
-        if (isset($digest['username']) === false || $this->_check_login($digest['username'], true) === false) {
+        $username = $this->_check_login($digest['username'], true);
+        if (isset($digest['username']) === false || $username === false) {
             $this->_force_login($unique_id);
         }
 
         $md5 = md5(strtoupper($this->request->method).':'.$digest['uri']);
-        $valid_response = md5($digest['username'].':'.$digest['nonce'].':'.$digest['nc'].':'.$digest['cnonce'].':'.$digest['qop'].':'.$md5);
+        $valid_response = md5($username.':'.$digest['nonce'].':'.$digest['nc'].':'.$digest['cnonce'].':'.$digest['qop'].':'.$md5);
 
         // Check if the string don't compare (case-insensitive)
         if (strcasecmp($digest['response'], $valid_response) !== 0) {


### PR DESCRIPTION
Fix $valid_response on _prepare_digest_auth() using md5(username:restrealm:password) from _check_login()

