### PR TITLE
Fix handling null in to_xml()

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -215,7 +215,7 @@ class Format
                 $this->to_xml($value, $node, $key);
             } else {
                 // add single node.
-                $value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
+                $value = htmlspecialchars(html_entity_decode($value ?? '', ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
 
                 $structure->addChild($key, $value);
             }


### PR DESCRIPTION
Addresses PHP 8.1+ compatibility (if you passed null to `html_entity_decode()` , it's not happy about it