### PR TITLE
Allow extending formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,56 @@ class Api extends RestController {
     }
 }
 ```
+
+## Extending supported formats
+
+If you need to be able to support more formats for replies, you can extend the
+`Format` class to add the required `to_...` methods
+
+1. Extend the `RestController` class (in `libraries/MY_REST_Controller.php`)
+```php
+<?php
+
+use chriskacerguis\RestServer\RestController;
+
+class MY_REST_Controller extends RestController
+{
+    public function __construct()
+    {
+        parent::__construct();
+        // This can be the library's chriskacerguis\RestServer\Format
+        // or your own custom overloaded Format class (see bellow)
+        $this->format = new Format();
+    }
+}
+```
+
+2. Extend the `Format` class (can be created as a CodeIgniter library in `libraries/Format.php`).
+Following is an example to add support for PDF output
+
+```php
+<?php
+
+use chriskacerguis\RestServer\Format as RestServerFormat;
+
+class Format extends RestServerFormat
+{
+    public function to_pdf($data = null)
+    {
+        if ($data === null && func_num_args() === 0) {
+            $data = $this->_data;
+        }
+
+        if (is_array($data) || substr($data, 0, 4) != '%PDF') {
+            $html = $this->to_html($data);
+
+            // Use your PDF lib of choice. For example mpdf
+            $mpdf = new \Mpdf\Mpdf();
+            $mpdf->WriteHTML($html);
+            return $mpdf->Output('', 'S');
+        }
+
+        return $data;
+    }
+}
+```

--- a/src/Format.php
+++ b/src/Format.php
@@ -215,7 +215,7 @@ class Format
                 $this->to_xml($value, $node, $key);
             } else {
                 // add single node.
-                $value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
+                $value = htmlspecialchars(html_entity_decode($value ?? '', ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8');
 
                 $structure->addChild($key, $value);
             }

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -639,7 +639,7 @@ class RestController extends \CI_Controller
                 $formatter = null;
                 if ($this->format && method_exists($this->format, 'to_'.$this->response->format)) {
                     $formatter = $this->format::factory($data);
-                } else if (method_exists(Format::class, 'to_'.$this->response->format)) {
+                } elseif (method_exists(Format::class, 'to_'.$this->response->format)) {
                     $formatter = Format::factory($data);
                 }
 

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -232,7 +232,7 @@ class RestController extends \CI_Controller
     /**
      * @var Format
      */
-    private $format;
+    protected $format;
 
     /**
      * @var bool
@@ -636,10 +636,17 @@ class RestController extends \CI_Controller
             // If data is not NULL and a HTTP status code provided, then continue
             elseif ($data !== null) {
                 // If the format method exists, call and return the output in that format
-                if (method_exists(Format::class, 'to_'.$this->response->format)) {
+                $formatter = null;
+                if ($this->format && method_exists($this->format, 'to_'.$this->response->format)) {
+                    $formatter = $this->format::factory($data);
+                } else if (method_exists(Format::class, 'to_'.$this->response->format)) {
+                    $formatter = Format::factory($data);
+                }
+
+                if ($formatter !== null) {
                     // CORB protection
                     // First, get the output content.
-                    $output = Format::factory($data)->{'to_'.$this->response->format}();
+                    $output = $formatter->{'to_'.$this->response->format}();
 
                     // Set the format header
                     // Then, check if the client asked for a callback, and if the output contains this callback :


### PR DESCRIPTION
This patch allows the class to be extended in a way that additional outputs can be defined.

General workflow
- Extend `Format` class to define addtional to_ methods (for example `to_pdf`)
- Extend the `RestController` method to define the `format` variable

In the old version this was possible by replacing the `Format` class entirely (because it wasn't using name spaces, it could be replaced). This is back-porting this functionality in a way.