### PR TITLE
Add support for expiring api keys

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -880,6 +880,10 @@ class RestController extends \CI_Controller
                 return false;
             }
 
+            if ($this->config->item('rest_keys_expire')===true && $row->{$this->config->item('rest_keys_expiry_column')} < time()) {
+                return false;
+            }
+
             isset($row->user_id) && $this->rest->user_id = $row->user_id;
             isset($row->level) && $this->rest->level = $row->level;
             isset($row->ignore_limits) && $this->rest->ignore_limits = $row->ignore_limits;

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -880,7 +880,7 @@ class RestController extends \CI_Controller
                 return false;
             }
 
-            if ($this->config->item('rest_keys_expire')===true && $row->{$this->config->item('rest_keys_expiry_column')} < time()) {
+            if ($this->config->item('rest_keys_expire') === true && $row->{$this->config->item('rest_keys_expiry_column')} < time()) {
                 return false;
             }
 

--- a/src/rest.php
+++ b/src/rest.php
@@ -355,9 +355,9 @@ $config['rest_key_column'] = 'key';
 | REST Table Key Expiry Config and Column Name
 |--------------------------------------------------------------------------
 |
-| Configure wether or not api keys should expire, and the column name to 
+| Configure wether or not api keys should expire, and the column name to
 | match e.g. expires
-| Note: the value in the column will be treated as a unix timestamp and 
+| Note: the value in the column will be treated as a unix timestamp and
 | compared with php function time()
 |
 */

--- a/src/rest.php
+++ b/src/rest.php
@@ -319,6 +319,7 @@ $config['rest_keys_table'] = 'keys';
 |       `is_private_key` TINYINT(1)  NOT NULL DEFAULT '0',
 |       `ip_addresses` TEXT NULL DEFAULT NULL,
 |       `date_created` INT(11) NOT NULL,
+|       `expires` INT(11) NOT NULL
 |       PRIMARY KEY (`id`)
 |   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 |
@@ -332,6 +333,7 @@ $config['rest_keys_table'] = 'keys';
 |       is_private_key SMALLINT NOT NULL DEFAULT '0',
 |       ip_addresses TEXT NULL DEFAULT NULL,
 |       date_created INT NOT NULL,
+|       expires INT NOT NULL,
 |       PRIMARY KEY (id)
 |   ) ;
 |  |
@@ -348,6 +350,19 @@ $config['rest_enable_keys'] = false;
 |
 */
 $config['rest_key_column'] = 'key';
+/*
+|--------------------------------------------------------------------------
+| REST Table Key Expiry Config and Column Name
+|--------------------------------------------------------------------------
+|
+| Configure wether or not api keys should expire, and the column name to 
+| match e.g. expires
+| Note: the value in the column will be treated as a unix timestamp and 
+| compared with php function time()
+|
+*/
+$config['rest_keys_expire'] = false;
+$config['rest_keys_expiry_column'] = 'expires';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Adds basic support for expiring api keys by checking if the enable flag is configured, and compares the timestamp in the configured column to the current system unix time using time() function